### PR TITLE
Fix Missing-Annotation Error in Exitron Calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2024-02-12
+
+### Added
+
+- added input directive in rule `prepare_cds` (exitron rules). Makes sure that annotations are present if exitron calling is executed first
+
 ## [0.1.3] - 2024-02-10
 
 ### Added
@@ -26,7 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed errors when providing custom input for MHC alleles
 - Refactoring of genotyping scripts 
 - Added more detailed instructions in README
-
 
 ## [0.1.0] - 2023-08-17
 

--- a/workflow/rules/exitron.smk
+++ b/workflow/rules/exitron.smk
@@ -15,6 +15,8 @@ rule download_genome:
     """
 
 rule prepare_cds:
+  input:
+    "resources/refs/genome.gtf"
   output:
     "resources/refs/CDS.bed"
   log:


### PR DESCRIPTION
When exitron calling is executed first (among other routines) - which requires the annotations an exception is caused. This is fixed in this PR. 