### PR TITLE
Fix Missing/Outdated Genome in Exitron Calling (Switch to ENSEMBL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.1.5] - 2024-02-13
+
+### Fix 
+
+- fixed wrong reference genome in exitron2vcf call (which forced ScanNeo2 to use alternative rules)
+- removed redundant rules for alternative genomes (ScanNeo2 now uses ensembl globally)
+
 ## [0.1.4] - 2024-02-12
 
 ### Added

--- a/workflow/rules/exitron.smk
+++ b/workflow/rules/exitron.smk
@@ -1,19 +1,3 @@
-rule download_genome:
-  output:
-    "resources/refs/hg38.fa",
-    "resources/refs/gencode.v37.annotation.gtf"
-  log:
-    "logs/prepare_cds.log"
-  conda:
-    "../envs/basic.yml"
-  shell:
-    """
-      curl -L https://hgdownload.cse.ucsc.edu/goldenpath/hg38/bigZips/hg38.fa.gz \
-          | gzip -d > resources/refs/hg38.fa 
-      curl -L  https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_37/gencode.v37.annotation.gtf.gz \
-          | gzip -d > resources/refs/gencode.v37.annotation.gtf
-    """
-
 rule prepare_cds:
   input:
     "resources/refs/genome.gtf"
@@ -31,6 +15,10 @@ rule prepare_cds:
     """
 
 rule prepare_scanexitron_config:
+  input:
+    genome="resources/refs/genome.fasta",
+    annotation="resources/refs/genome.gtf",
+    cds="resources/refs/CDS.bed"
   output:
     "resources/scanexitron_config.ini"
   log:
@@ -40,9 +28,9 @@ rule prepare_scanexitron_config:
   shell:
     """
       python3 workflow/scripts/prep_scanexitron_config.py \
-          resources/refs/genome.fasta \
-          resources/refs/genome.gtf \
-          resources/refs/CDS.bed \
+          {input.genome} \
+          {input.annotation} \
+          {input.cds} \
           {output} > {log}
     """
       
@@ -95,7 +83,7 @@ rule exitron_to_vcf:
     """
       python workflow/scripts/exitron2vcf.py \
         {input} {output} \
-        resources/refs/hg38.fa > {log}
+        resources/refs/genome.fasta > {log}
     """
 
 rule exitron_augment:

--- a/workflow/rules/indel.smk
+++ b/workflow/rules/indel.smk
@@ -50,7 +50,7 @@ rule detect_long_indel_ti_call:
     output:
         "results/{sample}/{seqtype}/indel/transindel/{group}_call.indel.vcf"
     message:
-      "Calling short indels using transindel on sample:{wildcards.sample} with group:{wildcards.group}"
+      "Calling long indels using transindel on sample:{wildcards.sample} with group:{wildcards.group}"
     log:
         "logs/{sample}/transindel/{seqtype}_{group}_call.log"
     conda:
@@ -73,7 +73,7 @@ rule long_indel_augment:
     output:
         "results/{sample}/{seqtype}/indel/transindel/{group}_long.indels_augmented.vcf"
     message:
-      "Augment indels with group and source information and resolving alleles and removing PCR slippage using transindel on sample:{wildcards.group} with replicate:{wildcards.group}"
+      "Augment long indels with group and source information and resolving alleles and removing PCR slippage using transindel on sample:{wildcards.group} with replicate:{wildcards.group}"
     log:
         "logs/{sample}/transindel/{seqtype}_{group}_sliprem.log"
     conda:


### PR DESCRIPTION
In the exitron calling routines (especially when converting the exitron results to vcf) a custom reference has been used. This has been updated to ENSEMBL