### PR TITLE
sort reads by QNAME before splitting

### DIFF
--- a/workflow/rules/hlatyping_mhcI.smk
+++ b/workflow/rules/hlatyping_mhcI.smk
@@ -24,12 +24,11 @@ rule filter_reads_mhcI_SE:
           {input.reads} | samtools view -h -F 4 -b1 - -o {output.reads} > {log} 2>&1
     """
 
-rule sort_and_index_reads_mhcI_SE:
+rule sort_reads_mhcI_SE:
   input:
     "results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_SE.bam",
   output:
     bam="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_SE_sorted.bam",
-    idx="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_SE_sorted.bam.bai"
   message:
     "Sort the filtered {wildcards.nartype}seq reads for hlatyping of sample: {wildcards.sample}"
   threads: 4
@@ -42,7 +41,6 @@ rule sort_and_index_reads_mhcI_SE:
   shell:
     """
       samtools sort -n -@ {threads} -m4g {input} -o {output.bam} > {log} 2>&1
-      samtools index {output.bam} >> {log} 2>&1
     """
 
 checkpoint split_reads_mhcI_SE:
@@ -137,7 +135,6 @@ rule sort_and_index_reads_mhcI_PE:
     "results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE_{readpair}.bam",
   output:
     bam="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE_{readpair}_sorted.bam",
-    idx="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE_{readpair}_sorted.bam.bai"
   message:
     "Sort the filtered {wildcards.nartype}seq reads for hlatyping of sample: {wildcards.sample} with readpair: {wildcards.readpair}"
   threads: 4
@@ -150,15 +147,12 @@ rule sort_and_index_reads_mhcI_PE:
   shell:
     """
       samtools sort -n -@ {threads} -m4g {input} -o {output.bam} > {log} 2>&1
-      samtools index {output.bam} >> {log} 2>&1
     """
 
 checkpoint split_reads_mhcI_PE:
   input:
     fwd="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE_R1_sorted.bam",
-    fwd_idx="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE_R1_sorted.bam.bai",
     rev="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE_R2_sorted.bam",
-    rev_idx="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE_R2_sorted.bam.bai"
   output:
     directory("results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE/")
   message:
@@ -183,7 +177,7 @@ checkpoint split_reads_mhcI_PE:
           --OUTPUT {output} \
           --OUT_PREFIX R2 \
           --SPLIT_TO_N_READS 100000 \
-          > {log} 2>&1
+          >> {log} 2>&1
     """
 
 rule hlatyping_mhcI_PE:  


### PR DESCRIPTION
This PR sorts the reads during mhc_I genotyping (gather and scatter) by QNAME before splitting (this can cause reads to be splitter wrongly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved logging for HLA typing (MHC‑I) split steps to capture command output for easier diagnostics.
  * Streamlined read-sorting behavior for single‑end and paired‑end workflows: sorting is now name‑based and no longer produces accompanying index files.
  * Simplified paired‑end split inputs to reduce redundant outputs and clarify pipeline inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->