### PR TITLE
Standardize log paths and fix missing log redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Batch binding affinity predictions**: Split large FASTA files into batches of 500 sequences before sending to NetMHCpan/NetMHCIIpan, preventing indefinite hangs on large inputs (e.g., 3,700+ alternative splicing events). Also fixed `as_completed` loop running outside the executor context and added detailed progress logging. ([#58](https://github.com/ylab-hi/ScanNeo2/pull/58))
 
+### Refactored
+
+- **Standardize log paths and fix missing log redirects**: Unified log directory structure across all 138 rules (`logs/ref/`, `logs/download/`, `logs/{sample}/{stage}/`), added missing `> {log} 2>&1` redirects to ~40 shell rules, and fixed several log path bugs (typos, duplicates, SE/PE mismatches). ([#60](https://github.com/ylab-hi/ScanNeo2/pull/60))
+
 ## [0.3.7] - 2025-11-01
 
 ### Fix

--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -12,7 +12,7 @@ if config['data']['rnaseq_filetype'] == '.fastq' or config['data']['rnaseq_filet
     message:
       "Aligning reads from {wildcards.group} to genome using STAR"
     log:
-      "logs/{sample}/star_align/rnaseq_{group}.log"
+      "logs/{sample}/align/star_align_fastq_{group}.log"
     params:
       extra=lambda wildcards: f"""--outSAMtype BAM Unsorted \
           --genomeSAindexNbases 10 \
@@ -35,7 +35,7 @@ if config['data']['rnaseq_filetype'] == '.fastq' or config['data']['rnaseq_filet
     threads: config['threads']
     wrapper:
         "v2.2.1/bio/star/align"
-          
+
 ### align reads to genome using STAR (when reads are in BAM - no preprocessing performed)
 if config['data']['rnaseq_filetype'] == '.bam':
   checkpoint split_bamfile_RG:
@@ -46,14 +46,14 @@ if config['data']['rnaseq_filetype'] == '.bam':
     conda:
       "../envs/samtools.yml"
     log:
-      "logs/{sample}/samtools/split/{group}.logs"
+      "logs/{sample}/align/split_bamfile_RG_{group}.log"
     threads: 10
     shell:
       """
         mkdir -p {output}
         samtools split -@ {threads} \
         -u {output}/noRG.bam \
-        -h {input} -f {output}/%!.%. {input}
+        -h {input} -f {output}/%!.%. {input} > {log} 2>&1
       """
 
   rule bamfile_RG_to_fastq:
@@ -66,12 +66,13 @@ if config['data']['rnaseq_filetype'] == '.bam':
     conda:
       "../envs/samtools.yml"
     log:
-      "logs/{sample}/samtools/bam2fastq/{group}_{rg}.log"
+      "logs/{sample}/align/bamfile_RG_to_fastq_{group}_{rg}.log"
     threads: config['threads']
     shell:
       """
-        samtools collate -Oun128 -@ {threads} {input} \
-            | samtools fastq -OT RG -@ {threads} - | gzip -c - > {output}
+        (samtools collate -Oun128 -@ {threads} {input} \
+            | samtools fastq -OT RG -@ {threads} - \
+            | gzip -c - > {output}) 2> {log}
       """
 
   rule star_align_bamfile:
@@ -84,7 +85,7 @@ if config['data']['rnaseq_filetype'] == '.bam':
       log="results/{sample}/rnaseq/align/{group}/{rg}.log",
       sj="results/{sample}/rnaseq/align/{group}/{rg}.tab"
     log:
-      "logs/{sample}/star_align/bam/{group}_{rg}.log"
+      "logs/{sample}/align/star_align_bamfile_{group}_{rg}.log"
     params:
       extra=lambda wildcards: f"""--outSAMtype BAM Unsorted --genomeSAindexNbases 10 \
         --readFilesCommand zcat \
@@ -105,14 +106,14 @@ if config['data']['rnaseq_filetype'] == '.bam':
     threads: config['threads']
     wrapper:
       "v1.26.0/bio/star/align"
-      
+
   rule merge_alignment_results:
     input:
       aggregate_aligned_rg
     output:
       "results/{sample}/rnaseq/align/{group}_aligned_STAR.bam"
     log:
-      "logs/{sample}/samtools/merge/{group}.log"
+      "logs/{sample}/align/merge_alignment_results_{group}.log"
     params:
       extra="",  # optional additional parameters as string
     threads: config['threads']
@@ -128,7 +129,7 @@ rule rnaseq_postproc_fixmate:
   conda:
     "../envs/samtools.yml"
   log:
-    "logs/{sample}/postproc/rnaseq_{group}_fixmate.log"
+    "logs/{sample}/align/rnaseq_postproc_fixmate_{group}.log"
   threads: 4
   params:
     mapq="--min-MQ config['mapq']"
@@ -139,7 +140,7 @@ rule rnaseq_postproc_fixmate:
       | samtools fixmate -pcmu -O bam -@ {threads} - {output} > {log} 2>&1
     """
 
-# sort and markdup needed to be separated (ensure no core dump for whatever reason) 
+# sort and markdup needed to be separated (ensure no core dump for whatever reason)
 rule rnaseq_postproc_markdup:
   input:
     bam="results/{sample}/rnaseq/align/{group}_fixmate_STAR.bam",
@@ -149,7 +150,7 @@ rule rnaseq_postproc_markdup:
   conda:
     "../envs/samtools.yml"
   log:
-    "logs/{sample}/postproc/rnaseq_{group}_markdup.log"
+    "logs/{sample}/align/rnaseq_postproc_markdup_{group}.log"
   threads: 4
   resources:
     mem_mb_per_cpu=4000
@@ -158,7 +159,7 @@ rule rnaseq_postproc_markdup:
       samtools sort -@4 -m4G -O BAM -T tmp/ {input.bam} \
           -o tmp/rnaseq_fixmate_sorted_{wildcards.sample}_{wildcards.group}.bam > {log} 2>&1
       samtools markdup -r -@4 tmp/rnaseq_fixmate_sorted_{wildcards.sample}_{wildcards.group}.bam \
-          {output} > {log} 2>&1 
+          {output} >> {log} 2>&1
       rm tmp/rnaseq_fixmate_sorted_{wildcards.sample}_{wildcards.group}.bam
     """
 
@@ -170,7 +171,7 @@ rule postproc_bam_index:
   conda:
     "../envs/samtools.yml"
   log:
-    "logs/{sample}/postproc/index/rnaseq_{group}.log"
+    "logs/{sample}/align/postproc_bam_index_{group}.log"
   shell:
     """
       samtools index {input} > {log} 2>&1
@@ -185,14 +186,14 @@ rule get_readgroups:
   conda:
       "../envs/basic.yml"
   log:
-        "logs/{sample}/get_readgroups/{seqtype}_{group}.log"
+        "logs/{sample}/align/get_readgroups_{seqtype}_{group}.log"
   shell:
     """
           python workflow/scripts/get_readgroups.py '{input}' \
           {output} > {log} 2>&1
       """
 
-# realign RNAseq and align DNAseq 
+# realign RNAseq and align DNAseq
 rule realign:
   input:
     bam=get_readgroups_input,
@@ -203,7 +204,7 @@ rule realign:
   conda:
     "../envs/realign.yml"
   log:
-    "logs/{sample}/realign/{seqtype}_{group}.log"
+    "logs/{sample}/align/realign_{seqtype}_{group}.log"
   threads: config['threads']
   shell:
     """
@@ -223,7 +224,7 @@ if config['data']['dnaseq_filetype'] in ['.fq','.fastq']:
     output:
       "results/{sample}/dnaseq/align/{group}_aligned_BWA.bam"
     log:
-      "logs/{sample}/bwa_align/dnaseq_{group}.log"
+      "logs/{sample}/align/bwa_align_dnaseq_{group}.log"
     conda:
       "../envs/realign.yml"
     params:
@@ -243,7 +244,7 @@ if config['data']['dnaseq_filetype'] in ['.fq','.fastq']:
     output:
       bam="results/{sample}/dnaseq/align/{group}_final_BWA.bam",
     log:
-      "logs/{sample}/postproc/dnaseq_{group}.log"
+      "logs/{sample}/align/dnaseq_postproc_{group}.log"
     conda:
       "../envs/samtools.yml"
     params:
@@ -257,14 +258,14 @@ if config['data']['dnaseq_filetype'] in ['.fq','.fastq']:
             | samtools sort -@ 4 -m1g -O bam -T tmp/ - -o - \
             | samtools markdup -r -@ 6 - {output.bam} > {log} 2>&1
       """
-    
+
 rule samtools_index_BWA_final:
     input:
         "results/{sample}/{seqtype}/align/{group}_final_BWA.bam",
     output:
         "results/{sample}/{seqtype}/align/{group}_final_BWA.bam.bai",
     log:
-        "logs/samtools_index/realign_{seqtype}_{sample}_{group}.log",
+        "logs/{sample}/align/samtools_index_BWA_final_{seqtype}_{group}.log",
     params:
         extra="",  # optional params string
     threads: 4  # This value - 1 will be sent to -@

--- a/workflow/rules/altsplicing.smk
+++ b/workflow/rules/altsplicing.smk
@@ -4,10 +4,10 @@ rule spladder:
         bamidx = "results/{sample}/rnaseq/align/{group}_final_STAR.bam.bai"
     output:
         directory("results/{sample}/rnaseq/altsplicing/spladder/{group}")
-    conda: 
+    conda:
         "../envs/spladder.yml"
     log:
-        "logs/{sample}/spladder/{group}_build.log"
+        "logs/{sample}/altsplicing/spladder_{group}.log"
     params:
       confidence=f"""{config["altsplicing"]["confidence"]}""",
       iteration=f"""{config["altsplicing"]["iterations"]}""",
@@ -23,7 +23,7 @@ rule spladder:
             {params.confidence} \
             {params.iteration} \
             {params.edgelimit} \
-            {log} 
+            {log}
       """
 
 rule splicing_to_vcf:
@@ -34,7 +34,7 @@ rule splicing_to_vcf:
   message:
     "Converting splicing events to VCF format"
   log:
-    "logs/{sample}/spladder/{group}_to_vcf.log"
+    "logs/{sample}/altsplicing/splicing_to_vcf_{group}.log"
   conda:
     "../envs/manipulate_vcf.yml"
   shell:
@@ -52,7 +52,7 @@ rule sort_altsplicing:
   message:
     "Sorting and compressing splicing events on sample:{wildcards.sample} of group:{wildcards.group}"
   log:
-    "logs/{sample}/spladder/{group}_sort.log"
+    "logs/{sample}/altsplicing/sort_altsplicing_{group}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -66,9 +66,9 @@ rule combine_altsplicing:
   output:
     "results/{sample}/variants/altsplicing.vcf.gz"
   message:
-    "Combining exitrons on sample:{wildcards.sample}"
+    "Combining alternative splicing events on sample:{wildcards.sample}"
   log:
-    "logs/{sample}/exitrons/combine_exitrons.log"
+    "logs/{sample}/altsplicing/combine_altsplicing.log"
   conda:
     "../envs/bcftools.yml"
   shell:

--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -4,17 +4,17 @@ rule download_vep_plugins:
   message:
     "Downloading VEP plugins"
   log: 
-    "logs/vep/download_plugins.log"
+    "logs/download/vep_plugins.log"
   conda:
     "../envs/basic.yml"
   params:
     release=f"""{config['reference']['release']}"""
   shell:
     """
-      mkdir -p resources/vep/plugins/
+      (mkdir -p resources/vep/plugins/
       curl -L -o {output}/NMD.pm https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/{params.release}/NMD.pm
       curl -L -o {output}/Downstream.pm https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/{params.release}/Downstream.pm
-      curl -L -o {output}/Wildtype.pm https://raw.githubusercontent.com/griffithlab/pVAC-Seq/master/pvacseq/VEP_plugins/Wildtype.pm
+      curl -L -o {output}/Wildtype.pm https://raw.githubusercontent.com/griffithlab/pVAC-Seq/master/pvacseq/VEP_plugins/Wildtype.pm) > {log} 2>&1
     """
 
 rule download_vep_cache:
@@ -23,14 +23,14 @@ rule download_vep_cache:
   message:
     "Downloading VEP cache"
   log:
-    "logs/vep/cache.log"
+    "logs/download/vep_cache.log"
   conda:
     "../envs/basic.yml"
   params:
     release=f"""{config['reference']['release']}"""
   shell:
     """
-      mkdir -p {output}
+      (mkdir -p {output}
       curl -L -C - \
           --retry 10 \
           --retry-delay 10 \
@@ -39,7 +39,7 @@ rule download_vep_cache:
           https://ftp.ensembl.org/pub/release-{params.release}/variation/indexed_vep_cache/homo_sapiens_vep_{params.release}_GRCh38.tar.gz
 
       tar -xzf resources/vep/cache/homo_sapiens_vep_{params.release}_GRCh38.tar.gz -C resources/vep/cache/
-      rm resources/vep/cache/homo_sapiens_vep_{params.release}_GRCh38.tar.gz
+      rm resources/vep/cache/homo_sapiens_vep_{params.release}_GRCh38.tar.gz) > {log} 2>&1
 
     """
 #      curl -L https://ftp.ensembl.org/pub/release-110/variation/indexed_vep_cache/homo_sapiens_vep_110_GRCh38.tar.gz \
@@ -53,12 +53,12 @@ rule index_variants:
   output:
     "results/{sample}/variants/{vartype}.vcf.gz.tbi"
   log:
-    "logs/indexvcf/{sample}_{vartype}.log"
+    "logs/{sample}/annotation/index_variants_{vartype}.log"
   conda:
     "../envs/samtools.yml"
   shell:
     """
-      tabix {input}
+      tabix {input} > {log} 2>&1
     """
 
 rule annotate_variants:
@@ -75,7 +75,7 @@ rule annotate_variants:
     plugins=["NMD","Wildtype","Downstream"],
     extra="--everything",  # optional: extra arguments
   log:
-    "logs/vep/{sample}_{vartype}_annotate.log",
+    "logs/{sample}/annotation/annotate_variants_{vartype}.log",
   threads: 4
   wrapper:
     "v5.9.0/bio/vep/annotate"

--- a/workflow/rules/exitron.smk
+++ b/workflow/rules/exitron.smk
@@ -4,14 +4,14 @@ rule prepare_cds:
   output:
     "resources/refs/CDS.bed"
   log:
-    "logs/prepare_cds.log"
+    "logs/ref/prepare_cds.log"
   conda:
     "../envs/basic.yml"
   shell:
     """
       cat resources/refs/genome.gtf \
           | awk 'OFS="\\t" {{if ($3=="CDS") {{print $1,$4-1,$5,$10,$16,$7}}}}' \
-          | tr -d '";' > {output}
+          | tr -d '";' > {output} 2> {log}
     """
 
 rule prepare_scanexitron_config:
@@ -22,7 +22,7 @@ rule prepare_scanexitron_config:
   output:
     "resources/scanexitron_config.ini"
   log:
-    "logs/prepare_scanexitron_config.log"
+    "logs/ref/prepare_scanexitron_config.log"
   conda:
     "../envs/basic.yml"
   shell:
@@ -31,11 +31,11 @@ rule prepare_scanexitron_config:
           {input.genome} \
           {input.annotation} \
           {input.cds} \
-          {output} > {log}
+          {output} > {log} 2>&1
     """
-      
+
 rule scanexitron:
-    input: 
+    input:
         bam = "results/{sample}/rnaseq/align/{group}_final_STAR.bam",
         idx = "results/{sample}/rnaseq/align/{group}_final_STAR.bam.bai",
         fasta = "resources/refs/genome.fasta",
@@ -47,7 +47,7 @@ rule scanexitron:
     message:
       "Detect exitrons on sample:{wildcards.sample} of group:{wildcards.group}"
     log:
-        "logs/scanexitron_{sample}_{group}.log"
+        "logs/{sample}/exitron/scanexitron_{group}.log"
     conda:
       "../envs/scanexitron.yml"
     threads:
@@ -67,7 +67,7 @@ rule scanexitron:
           -c ../../../{input.config} \
           -s {params.strand} \
           -i {input.bam} \
-          -r hg38
+          -r hg38 > {log} 2>&1
         mv {wildcards.group}_final_STAR.exitron {output}
         mv {wildcards.group}_final_STAR* results/{wildcards.sample}/rnaseq/exitron/
       """
@@ -78,14 +78,14 @@ rule exitron_to_vcf:
   output:
     "results/{sample}/rnaseq/exitron/{group}_exitrons.vcf"
   log:
-    "logs/exitron2vcf_{sample}_{group}.log"
+    "logs/{sample}/exitron/exitron_to_vcf_{group}.log"
   conda:
     "../envs/manipulate_vcf.yml"
   shell:
     """
       python workflow/scripts/exitron2vcf.py \
         {input} {output} \
-        resources/refs/genome.fasta > {log}
+        resources/refs/genome.fasta > {log} 2>&1
     """
 
 rule exitron_augment:
@@ -96,7 +96,7 @@ rule exitron_augment:
   message:
     "Augmenting exitrons on sample:{wildcards.sample} of group:{wildcards.group}"
   log:
-    "logs/{sample}/exitron/{group}_exitron_augment.log"
+    "logs/{sample}/exitron/exitron_augment_{group}.log"
   conda:
     "../envs/manipulate_vcf.yml"
   shell:
@@ -116,7 +116,7 @@ rule sort_exitron:
   message:
     "Sorting and compressing exitrons on sample:{wildcards.sample} of group:{wildcards.group}"
   log:
-    "logs/exitron_sort_{sample}_{group}.log"
+    "logs/{sample}/exitron/sort_exitron_{group}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -132,7 +132,7 @@ rule combine_exitrons:
   message:
     "Combining exitrons on sample:{wildcards.sample}"
   log:
-    "logs/{sample}/exitrons/combine_exitrons.log"
+    "logs/{sample}/exitron/combine_exitrons.log"
   conda:
     "../envs/bcftools.yml"
   shell:

--- a/workflow/rules/genefusion.smk
+++ b/workflow/rules/genefusion.smk
@@ -8,7 +8,7 @@ rule arriba:
         fusions="results/{sample}/rnaseq/genefusion/{group}_fusions.tsv",
         discarded="results/{sample}/rnaseq/genefusion/{group}_fusions.discarded.tsv",  # optional
     log:
-        "logs/{sample}/arriba/{group}.log",
+        "logs/{sample}/genefusion/arriba_{group}.log",
     params:
         genome_build="GRCh38",
         default_blacklist=False,  # optional

--- a/workflow/rules/germline.smk
+++ b/workflow/rules/germline.smk
@@ -15,12 +15,12 @@ rule get_gatk_vqsr_training_sets:
   message:
     "Downloading training sets for calling high confidence variants"
   log:
-    "logs/gatk_get_training_sets.log"
+    "logs/download/gatk_vqsr_training_sets.log"
   conda:
     "../envs/basic.yml"
   shell:
     """
-    curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/hapmap_3.3.hg38.vcf.gz -o resources/vqsr/hapmap_3.3.hg38.vcf.gz
+    (curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/hapmap_3.3.hg38.vcf.gz -o resources/vqsr/hapmap_3.3.hg38.vcf.gz
     curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/hapmap_3.3.hg38.vcf.gz.tbi -o resources/vqsr/hapmap_3.3.hg38.vcf.gz.tbi
     curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/1000G_omni2.5.hg38.vcf.gz -o resources/vqsr/1000G_omni2.5.hg38.vcf.gz
     curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/1000G_omni2.5.hg38.vcf.gz.tbi -o resources/vqsr/1000G_omni2.5.hg38.vcf.gz.tbi
@@ -29,7 +29,7 @@ rule get_gatk_vqsr_training_sets:
     curl -L https://ftp.ncbi.nlm.nih.gov/snp/organisms/human_9606_b150_GRCh38p7/VCF/GATK/00-common_all.vcf.gz  -o resources/vqsr/dbSNP_b150.vcf.gz
     curl -L https://ftp.ncbi.nlm.nih.gov/snp/organisms/human_9606_b150_GRCh38p7/VCF/GATK/00-common_all.vcf.gz.tbi  -o resources/vqsr/dbSNP_b150.vcf.gz.tbi
     curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz -o resources/vqsr/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz
-    curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi -o resources/vqsr/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi
+    curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi -o resources/vqsr/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi) > {log} 2>&1
     """
 
 # do a first round of variant calling on original, unrecalibrated data
@@ -44,13 +44,13 @@ checkpoint split_bam_htc_first_round:
   message:
     "Splitting bam file for first round of variant calling (htcaller) on original, unrecalibrated data on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-    "logs/{sample}/align/{seqtype}_{group}_split.log"
+    "logs/{sample}/germline/split_bam_htc_1rd_{seqtype}_{group}.log"
   conda:
     "../envs/basic.yml"
   shell:
     """
       python workflow/scripts/split_bam_by_chr.py \
-          {input.bam} {output}
+          {input.bam} {output} > {log} 2>&1
     """
 
 rule index_split_bam_htc_first_round:
@@ -61,7 +61,7 @@ rule index_split_bam_htc_first_round:
   message:
     "Indexing split bam file for first round of variant calling (htcaller) on original, unrecalibrated data on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-    "logs/{sample}/align/{seqtype}_{group}_split_{chr}_index.log"
+    "logs/{sample}/germline/index_split_bam_htc_1rd_{seqtype}_{group}_{chr}.log"
   conda:
     "../envs/samtools.yml"
   shell:
@@ -80,7 +80,7 @@ rule detect_variants_htc_first_round:
   message:
     "First round of variant calling (htcaller) on original, unrecalibrated data on sample:{wildcards.sample} with group:{wildcards.group} on chromosome {wildcards.chr}"
   log:
-    "logs/{sample}/gatk/haplotypecaller/{seqtype}_{group}_1rd_{chr}.log",
+    "logs/{sample}/germline/detect_variants_htc_1rd_{seqtype}_{group}_{chr}.log",
   threads: 4
   resources:
     mem_mb=1024
@@ -95,7 +95,7 @@ rule sort_variants_htc_first_round:
   message:
     "Sorting vcf file from first round of variant calling (htcaller) on original, unrecalibrated data on sample:{wildcards.sample} with group:{wildcards.group} on chromosome {wildcards.chr}"
   log:
-    "logs/{sample}/gatk/haplotypecaller/{seqtype}_{group}_1rd_{chr}_sort.log"
+    "logs/{sample}/germline/sort_variants_htc_1rd_{seqtype}_{group}_{chr}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -111,7 +111,7 @@ rule index_variants_htc_first_round:
   message:
     "Indexing vcf file from first round of variant calling (htcaller) on original, unrecalibrated data on sample:{wildcards.sample} with group:{wildcards.group} on chromosome {wildcards.chr}"
   log:
-     "logs/{sample}/gatk/haplotypecaller/{seqtype}_{group}_1rd_{chr}_index.log"
+    "logs/{sample}/germline/index_variants_htc_1rd_{seqtype}_{group}_{chr}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -128,14 +128,14 @@ rule merge_variants_htc_first_round:
   message:
     "Merging vcf files from first round of variant calling (htcaller) on original, unrecalibrated data on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-    "logs/{sample}/gatk/haplotypecaller/{seqtype}_{group}_1rd_merge.log"
+    "logs/{sample}/germline/merge_variants_htc_1rd_{seqtype}_{group}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
     """
       bcftools concat --naive-force -O z {input.vcf} -o - | bcftools sort -O z -o {output} > {log} 2>&1
     """
-      
+
 rule index_merged_variants_htc_first_round:
   input:
     "results/{sample}/{seqtype}/indel/htcaller/{group}_variants.1rd.vcf.gz"
@@ -144,7 +144,7 @@ rule index_merged_variants_htc_first_round:
   message:
     "Indexing merged vcf file from first round of variant calling (htcaller) on original, unrecalibrated data on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-    "logs/{sample}/gatk/haplotypecaller/{seqtype}_{group}_1rd_index.log"
+    "logs/{sample}/germline/index_merged_variants_htc_1rd_{seqtype}_{group}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -152,7 +152,7 @@ rule index_merged_variants_htc_first_round:
       bcftools index -t {input} > {log} 2>&1
     """
 
-      
+
 # recalibrate variants (SNP)
 rule recalibrate_variants_first_round:
   input:
@@ -170,9 +170,9 @@ rule recalibrate_variants_first_round:
   message:
     "Recalibrate variants (SNP) on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-    "logs/{sample}/gatk/vqsr/{seqtype}_{group}_variants.1rd.recal.log"
+    "logs/{sample}/germline/recalibrate_variants_1rd_{seqtype}_{group}.log"
   params:
-    mode="BOTH", 
+    mode="BOTH",
     resources={
         "hapmap": {"known": False, "training": True, "truth": True, "prior": 15.0},
         "omni": {"known": False, "training": True, "truth": True, "prior": 12.0},
@@ -201,7 +201,7 @@ rule apply_VQSR_SNVs_first_round:
   message:
     "Apply VQSR (SNP) on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-      "logs/{sample}/gatk/vqsr/{seqtype}_{group}_apply.1rd.snvs.log"
+      "logs/{sample}/germline/apply_VQSR_SNVs_1rd_{seqtype}_{group}.log"
   params:
       mode="SNP",  # set mode, must be either SNP, INDEL or BOTH
       extra="--truth-sensitivity-filter-level 99.5",  # optional
@@ -222,7 +222,7 @@ rule apply_VSQR_INDEL_first_round:
   message:
     "Apply VQSR (INDEL) on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-      "logs/{sample}/gatk/vqsr/{seqtype}_{group}_apply.1rd.indels.log"
+      "logs/{sample}/germline/apply_VQSR_INDEL_1rd_{seqtype}_{group}.log"
   params:
       mode="INDEL",  # set mode, must be either SNP, INDEL or BOTH
       extra="--truth-sensitivity-filter-level 99.5",  # optional
@@ -230,18 +230,18 @@ rule apply_VSQR_INDEL_first_round:
       mem_mb=1024,
   wrapper:
       "v1.31.1/bio/gatk/applyvqsr"
-    
+
 rule recalibrate_bases:
   input:
     bam="results/{sample}/{seqtype}/align/{group}_final_BWA.bam",
     ref="resources/refs/genome.fasta",
     dict="resources/refs/genome.dict",
-    known=["results/{sample}/{seqtype}/indel/htcaller/{group}_indels.1rd.flt.vcf", 
+    known=["results/{sample}/{seqtype}/indel/htcaller/{group}_indels.1rd.flt.vcf",
       "results/{sample}/{seqtype}/indel/htcaller/{group}_snvs.1rd.flt.vcf"]
   output:
     recal_table="results/{sample}/{seqtype}/indel/htcaller/{group}_variants.1rd.baserecal.grp"
   log:
-    "logs/{sample}/gatk/baserecalibrator/{seqtype}_{group}.log"
+    "logs/{sample}/germline/recalibrate_bases_{seqtype}_{group}.log"
   params:
     extra="",  # optional
     java_opts="",  # optional
@@ -259,7 +259,7 @@ rule apply_BQSR:
   output:
     bam="results/{sample}/{seqtype}/indel/htcaller/{group}_variants.1rd.baserecal.bam"
   log:
-    "logs/{sample}/gatk/gatk_applybqsr/{seqtype}_{group}.log",
+    "logs/{sample}/germline/apply_BQSR_{seqtype}_{group}.log",
   params:
     extra="",  # optional
     java_opts="",  # optional
@@ -275,7 +275,7 @@ rule index_bases_recal:
     output:
         "results/{sample}/{seqtype}/indel/htcaller/{group}_variants.1rd.baserecal.bam.bai"
     log:
-        "logs/{sample}/{seqtype}/indel/htcaller/index_recal_{group}.log",
+        "logs/{sample}/germline/index_bases_recal_{seqtype}_{group}.log",
     params:
         extra="",  # optional params string
     threads: 4  # This value - 1 will be sent to -@
@@ -294,13 +294,13 @@ checkpoint split_bam_htc_final_round:
   message:
     "Splitting bam file for the final round of variant calling (htcaller) on recalibrated data on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-    "logs/{sample}/indel/gatk/haplotypecaller/split_recal_{seqtype}_{group}.log"
+    "logs/{sample}/germline/split_bam_htc_final_{seqtype}_{group}.log"
   conda:
     "../envs/basic.yml"
   shell:
     """
       python workflow/scripts/split_bam_by_chr.py \
-          {input.bam} {output}
+          {input.bam} {output} > {log} 2>&1
     """
 
 rule index_split_bam_htc_final_round:
@@ -311,7 +311,7 @@ rule index_split_bam_htc_final_round:
   message:
     "Indexing split bam file for the final round of variant calling (htcaller) on recalibrated data on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-    "logs/{sample}/indel/gatk/haplotypecaller/index_recal_{seqtype}_{group}_{chr}.log"
+    "logs/{sample}/germline/index_split_bam_htc_final_{seqtype}_{group}_{chr}.log"
   conda:
     "../envs/samtools.yml"
   shell:
@@ -327,9 +327,9 @@ rule detect_variants_htc_final_round:
   output:
     vcf="results/{sample}/{seqtype}/indel/htcaller/{group}_variants.final/{chr}.vcf"
   message:
-    "First round of variant calling (htcaller) on original, unrecalibrated data on sample:{wildcards.sample} with group:{wildcards.group} on chromosome {wildcards.chr}"
+    "Final round of variant calling (htcaller) on recalibrated data on sample:{wildcards.sample} with group:{wildcards.group} on chromosome {wildcards.chr}"
   log:
-    "logs/{sample}/indel/gatk/haplotypecaller/htc_final_{seqtype}_{group}_{chr}.log",
+    "logs/{sample}/germline/detect_variants_htc_final_{seqtype}_{group}_{chr}.log",
   threads: 4
   resources:
     mem_mb=1024
@@ -344,7 +344,7 @@ rule sort_variants_htc_final_round:
   message:
     "Sorting vcf file from final round of variant calling (htcaller) on recalibrated data on sample:{wildcards.sample} with group:{wildcards.group} on chromosome {wildcards.chr}"
   log:
-    "logs/{sample}/indel/gatk/haplotypecaller/sort_final_{seqtype}_{group}_{chr}.log"
+    "logs/{sample}/germline/sort_variants_htc_final_{seqtype}_{group}_{chr}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -360,7 +360,7 @@ rule index_variants_htc_final_round:
   message:
     "Indexing vcf file from final round of variant calling (htcaller) on recalibrated data on sample:{wildcards.sample} with group:{wildcards.group} on chromosome {wildcards.chr}"
   log:
-     "logs/{sample}/indel/gatk/haplotypecaller/index_final_{seqtype}_{group}_{chr}.log"
+    "logs/{sample}/germline/index_variants_htc_final_{seqtype}_{group}_{chr}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -375,9 +375,9 @@ rule merge_variants_htc_final_round:
   output:
     "results/{sample}/{seqtype}/indel/htcaller/{group}_variants.final.vcf.gz"
   message:
-    "Merging vcf files from first round of variant calling (htcaller) on original, unrecalibrated data on sample:{wildcards.sample} with group:{wildcards.group}"
+    "Merging vcf files from final round of variant calling (htcaller) on recalibrated data on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-    "logs/{sample}/indel/gatk/haplotypecaller/merge_final_{seqtype}_{group}.log"
+    "logs/{sample}/germline/merge_variants_htc_final_{seqtype}_{group}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -393,7 +393,7 @@ rule index_merged_variants_htc_final_round:
   message:
     "Indexing merged vcf file from final round of variant calling (htcaller) on recalibrated data on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-    "logs/{sample}/indel/gatk/haplotypecaller/index_final_{seqtype}_{group}.log"
+    "logs/{sample}/germline/index_merged_variants_htc_final_{seqtype}_{group}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -402,7 +402,7 @@ rule index_merged_variants_htc_final_round:
     """
 
 
-# recalibrate variants 
+# recalibrate variants
 rule recalibrate_variants_final_round:
   input:
     vcf="results/{sample}/{seqtype}/indel/htcaller/{group}_variants.final.vcf.gz",
@@ -419,10 +419,10 @@ rule recalibrate_variants_final_round:
   message:
     "Recalibrate variants (SNP) on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-    "logs/{sample}/gatk/vqsr/{seqtype}_{group}_final.variants.recal.log"
+    "logs/{sample}/germline/recalibrate_variants_final_{seqtype}_{group}.log"
 
   params:
-    mode="BOTH", 
+    mode="BOTH",
     resources={
         "hapmap": {"known": False, "training": True, "truth": True, "prior": 15.0},
         "omni": {"known": False, "training": True, "truth": True, "prior": 12.0},
@@ -450,7 +450,7 @@ rule apply_VQSR_SNVs_final:
   message:
     "Apply VQSR (SNP) on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-    "logs/{sample}/gatk/vqsr/{seqtype}_{group}_apply.final.snvs.log"
+    "logs/{sample}/germline/apply_VQSR_SNVs_final_{seqtype}_{group}.log"
   params:
     mode="BOTH",  # set mode, must be either SNP, INDEL or BOTH
     extra="--truth-sensitivity-filter-level 99.5",  # optional
@@ -470,7 +470,7 @@ rule apply_VSQR_INDELS_final:
   message:
     "Apply VQSR (INDEL) on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-    "logs/{sample}/gatk/vqsr/{seqtype}_{group}_apply.final.indel.log"
+    "logs/{sample}/germline/apply_VQSR_INDELS_final_{seqtype}_{group}.log"
   params:
     mode="INDEL",  # set mode, must be either SNP, INDEL or BOTH
     extra="--truth-sensitivity-filter-level 99.5",  # optional

--- a/workflow/rules/hlatyping_mhcI.smk
+++ b/workflow/rules/hlatyping_mhcI.smk
@@ -7,7 +7,7 @@ rule filter_reads_mhcI_SE:
     panel=multiext("resources/hla/yara_index/{nartype}",
         ".lf.drp", ".lf.drs", ".lf.drv",
         ".lf.pst", ".rid.concat", ".rid.limits",
-        ".sa.ind", ".sa.len", ".sa.val", 
+        ".sa.ind", ".sa.len", ".sa.val",
         ".txt.concat", ".txt.limits", ".txt.size"),
   output:
     reads="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_SE.bam",
@@ -35,7 +35,7 @@ rule sort_reads_mhcI_SE:
   resources:
     mem_mb=20000
   log:
-    "logs/{sample}/hlatyping/sort_and_index_reads_mhcI_PE_{group}_{nartype}.log"
+    "logs/{sample}/hlatyping/sort_reads_mhcI_SE_{group}_{nartype}.log"
   conda:
     "../envs/samtools.yml"
   shell:
@@ -52,7 +52,7 @@ checkpoint split_reads_mhcI_SE:
   message:
     "Splitting filtered group: {wildcards.group} BAM files ({wildcards.nartype}seq reads) for HLA typing"
   log:
-    "logs/{sample}/hlatyping/split_bam_mhcI_SE_{group}_{nartype}.log"
+    "logs/{sample}/hlatyping/split_reads_mhcI_SE_{group}_{nartype}.log"
   conda:
     "../envs/gatk.yml"
   threads: 1
@@ -67,7 +67,7 @@ checkpoint split_reads_mhcI_SE:
           > {log} 2>&1
     """
 
-rule hlatyping_mhcI_SE:  
+rule hlatyping_mhcI_SE:
   input:
     fwd="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_SE/R_{no}.bam",
     rev="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_SE/R_{no}.bam",
@@ -96,14 +96,14 @@ rule combine_hlatyping_mhcI_SE:
   message:
     "Combining HLA alleles from predicted optitype results from {wildcards.nartype}seq reads in group: {wildcards.group}"
   log:
-    "logs/{sample}/hlatyping/combine_optitype_mhcI_PE_{group}_{nartype}.log"
+    "logs/{sample}/hlatyping/combine_hlatyping_mhcI_SE_{group}_{nartype}.log"
   conda:
     "../envs/basic.yml"
   threads: 1
   shell:
     """
       python3 workflow/scripts/genotyping/combine_optitype_results.py \
-          '{input}' {wildcards.group} {output}
+          '{input}' {wildcards.group} {output} > {log} 2>&1
     """
 
 ############# paired-end reads ###########
@@ -113,7 +113,7 @@ rule filter_reads_mhcI_PE:
     panel=multiext("resources/hla/yara_index/{nartype}",
         ".lf.drp", ".lf.drs", ".lf.drv",
         ".lf.pst", ".rid.concat", ".rid.limits",
-        ".sa.ind", ".sa.len", ".sa.val", 
+        ".sa.ind", ".sa.len", ".sa.val",
         ".txt.concat", ".txt.limits", ".txt.size"),
   output:
     reads="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE_{readpair}.bam",
@@ -158,7 +158,7 @@ checkpoint split_reads_mhcI_PE:
   message:
     "Splitting filtered group: {wildcards.group} BAM files ({wildcards.nartype}seq reads) for HLA typing"
   log:
-    "logs/{sample}/hlatyping/split_bam_mhcI_PE_{group}_{nartype}.log"
+    "logs/{sample}/hlatyping/split_reads_mhcI_PE_{group}_{nartype}.log"
   conda:
     "../envs/gatk.yml"
   threads: 1
@@ -171,7 +171,7 @@ checkpoint split_reads_mhcI_PE:
           --OUT_PREFIX R1 \
           --SPLIT_TO_N_READS 100000 \
           > {log} 2>&1
-      
+
       gatk SplitSamByNumberOfReads \
           -I {input.rev} \
           --OUTPUT {output} \
@@ -180,7 +180,7 @@ checkpoint split_reads_mhcI_PE:
           >> {log} 2>&1
     """
 
-rule hlatyping_mhcI_PE:  
+rule hlatyping_mhcI_PE:
   input:
     fwd="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE/R1_{no}.bam",
     rev="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE/R2_{no}.bam",
@@ -209,14 +209,14 @@ rule combine_hlatyping_mhcI_PE:
   message:
     "Combining HLA alleles from predicted optitype results from {wildcards.nartype}seq reads in group: {wildcards.group}"
   log:
-    "logs/{sample}/hlatyping/combine_optitype_mhcI_PE_{group}_{nartype}.log"
+    "logs/{sample}/hlatyping/combine_hlatyping_mhcI_PE_{group}_{nartype}.log"
   conda:
     "../envs/basic.yml"
   threads: 1
   shell:
     """
       python3 workflow/scripts/genotyping/combine_optitype_results.py \
-          '{input}' {wildcards.group} {output}
+          '{input}' {wildcards.group} {output} > {log} 2>&1
     """
 
 rule combine_all_mhcI_alleles:
@@ -227,13 +227,13 @@ rule combine_all_mhcI_alleles:
   message:
     "Combining HLA alleles from different sources (e.g., predicted and user-defined alleles)"
   log:
-    "logs/{sample}/genotyping/combine_all_mhc-I.log"
+    "logs/{sample}/hlatyping/combine_all_mhcI_alleles.log"
   conda:
     "../envs/basic.yml"
   threads: 1
   shell:
     """
       python workflow/scripts/genotyping/combine_all_alleles.py \
-          '{input}' mhc-I {output}
+          '{input}' mhc-I {output} > {log} 2>&1
     """
 

--- a/workflow/rules/hlatyping_mhcII.smk
+++ b/workflow/rules/hlatyping_mhcII.smk
@@ -14,7 +14,7 @@ rule filter_reads_mhcII_SE:
   output:
     "results/{sample}/hla/mhc-II/reads/{group}_{nartype}_flt_SE.bam"
   log:
-    "logs/{sample}/genotyping/reads_filtering_mhc-II_{group}_{nartype}.log"
+    "logs/{sample}/hlatyping/filter_reads_mhcII_SE_{group}_{nartype}.log"
   params:
     extra="",  # optional parameters
   threads: config['threads']  # Use at least two threads
@@ -27,7 +27,7 @@ rule bam2fastq_reads_mhcII_SE:
   output:
     "results/{sample}/hla/mhc-II/reads/{group}_{nartype}_flt_SE.fq"
   log:
-    "logs/{sample}/genotyping/{group}_{nartype}_hla_sam.log"
+    "logs/{sample}/hlatyping/bam2fastq_reads_mhcII_SE_{group}_{nartype}.log"
   conda:
     "../envs/samtools.yml"
   threads: 1
@@ -51,7 +51,7 @@ rule filter_reads_mhcII_PE:
   output:
     "results/{sample}/hla/mhc-II/reads/{group}_{nartype}_flt_PE.bam"
   log:
-    "logs/{sample}/genotyping/reads_filtering_mhc-II_{group}_{nartype}.log"
+    "logs/{sample}/hlatyping/filter_reads_mhcII_PE_{group}_{nartype}.log"
   params:
     extra="",  # optional parameters
   threads: config['threads']  # Use at least two threads
@@ -66,7 +66,7 @@ rule finalize_reads_mhcII:
     fwd="results/{sample}/hla/mhc-II/reads/{group}_{nartype}_final_R1.fq",
     rev="results/{sample}/hla/mhc-II/reads/{group}_{nartype}_final_R2.fq"
   log:
-    "logs/{sample}/genotyping/finalize_reads_mhcII_{group}_{nartype}.log"
+    "logs/{sample}/hlatyping/finalize_reads_mhcII_{group}_{nartype}.log"
   conda:
     "../envs/basic.yml"
   threads: 1
@@ -75,17 +75,17 @@ rule finalize_reads_mhcII:
       python workflow/scripts/genotyping/finalize_mhcII_input.py \
           {input} \
           {output.fwd} \
-          {output.rev}
+          {output.rev} > {log} 2>&1
     """
 
 rule readcounts_mhcII:
-  input: 
+  input:
     fwd = "results/{sample}/hla/mhc-II/reads/{group}_{nartype}_final_R1.fq",
     rev = "results/{sample}/hla/mhc-II/reads/{group}_{nartype}_final_R2.fq"
   output:
     "results/{sample}/hla/mhc-II/reads/{group}_{nartype}_final_counts.txt"
   log:
-    "logs/{sample}/genotyping/final_readcounts_mhcII_{group}_{nartype}.log"
+    "logs/{sample}/hlatyping/readcounts_mhcII_{group}_{nartype}.log"
   conda:
     "../envs/basic.yml"
   threads: 1
@@ -103,7 +103,7 @@ rule hlatyping_mhcII:
   output:
     "results/{sample}/hla/mhc-II/genotyping/{group}_{nartype}/result/{group}_{nartype}_final.result.txt"
   log:
-    "logs/{sample}/hla/{group}_{nartype}_hlahd.log"
+    "logs/{sample}/hlatyping/hlatyping_mhcII_{group}_{nartype}.log"
   conda:
     "../envs/hlahd.yml"
   params:
@@ -132,7 +132,7 @@ rule merge_predicted_mhcII_allels:
   message:
     "Merging HLA alleles from different sources"
   log:
-    "logs/{sample}/genotyping/merge_predicted_mhc-II.log"
+    "logs/{sample}/hlatyping/merge_predicted_mhcII_alleles.log"
   conda:
     "../envs/basic.yml"
   threads: 1
@@ -152,7 +152,7 @@ rule combine_all_mhcII_alleles:
   message:
     "Combining HLA mhc-II alleles from different sources"
   log:
-    "logs/{sample}/genotyping/combine_all_mhc-II.log"
+    "logs/{sample}/hlatyping/combine_all_mhcII_alleles.log"
   conda:
     "../envs/basic.yml"
   threads: 1

--- a/workflow/rules/hlatyping_prep.smk
+++ b/workflow/rules/hlatyping_prep.smk
@@ -8,26 +8,26 @@ rule get_mhcI_hla_panel:
   conda:
     "../envs/basic.yml"
   log:
-    "logs/hlatyping/get_mhcI_hla_panel.log"
+    "logs/ref/get_mhcI_hla_panel.log"
   shell:
     """
-      curl -o {output.dna} https://raw.githubusercontent.com/FRED-2/OptiType/v1.3.5/data/hla_reference_dna.fasta
-      curl -o {output.rna} https://raw.githubusercontent.com/FRED-2/OptiType/v1.3.5/data/hla_reference_rna.fasta
+      (curl -o {output.dna} https://raw.githubusercontent.com/FRED-2/OptiType/v1.3.5/data/hla_reference_dna.fasta
+      curl -o {output.rna} https://raw.githubusercontent.com/FRED-2/OptiType/v1.3.5/data/hla_reference_rna.fasta) > {log} 2>&1
     """
 
 rule index_mhcI_hla_panel:
   input:
     fa="resources/hla/hla_ref_{nartype}.fa",
   output:
-    panel=multiext("resources/hla/yara_index/{nartype}", 
+    panel=multiext("resources/hla/yara_index/{nartype}",
                    ".lf.drp", ".lf.drs", ".lf.drv",
                    ".lf.pst", ".rid.concat", ".rid.limits",
-                   ".sa.ind", ".sa.len", ".sa.val", 
+                   ".sa.ind", ".sa.len", ".sa.val",
                    ".txt.concat", ".txt.limits", ".txt.size"),
   message:
     "Index MHC-I HLA reference panel ({wildcards.nartype})"
   log:
-    "logs/hlatyping/index_mhcI_hla_panel_{nartype}.log"
+    "logs/ref/index_mhcI_hla_panel_{nartype}.log"
   conda:
     "../envs/yara.yml"
   shell:
@@ -47,13 +47,13 @@ rule get_reads_hlatyping_BAM:
   message:
     "Retrieve reads for HLA genotyping by converting the alignments ({wildcards.nartype}) of group:{wildcards.group} from sample:{wildcards.sample} to reads in FASTQ format"
   log:
-    "logs/{sample}/hla/get_read_hlatyping_BAM_{group}_{nartype}.log"
+    "logs/{sample}/hlatyping/get_reads_hlatyping_BAM_{group}_{nartype}.log"
   conda:
     "../envs/samtools.yml"
   threads: 4
   shell:
     """
-      samtools sort -@ {threads} -n {input.reads} -T tmp/ \
-          | samtools fastq -@ {threads} > {output}
+      (samtools sort -@ {threads} -n {input.reads} -T tmp/ \
+          | samtools fastq -@ {threads} > {output}) 2> {log}
     """
 

--- a/workflow/rules/indel.smk
+++ b/workflow/rules/indel.smk
@@ -10,7 +10,7 @@ rule detect_long_indel_ti_build_RNA:
     message:
       "Building new BAM file with redefined CIGAR string using transindel build on sample:{wildcards.sample} with group:{wildcards.group}"
     log:
-        "logs/{sample}/transindel/{group}_build_RNA.log"
+        "logs/{sample}/indel/ti_build_RNA_{group}.log"
     conda:
         "../envs/transindel.yml"
     shell:
@@ -33,7 +33,7 @@ rule detect_long_indel_ti_build_DNA:
     message:
       "Building new BAM file with redefined CIGAR string using transindel build on sample:{wildcards.sample} with group:{wildcards.group}"
     log:
-        "logs/{sample}/transindel/{group}_build_DNA.log"
+        "logs/{sample}/indel/ti_build_DNA_{group}.log"
     conda:
         "../envs/transindel.yml"
     shell:
@@ -52,7 +52,7 @@ rule detect_long_indel_ti_call:
     message:
       "Calling long indels using transindel on sample:{wildcards.sample} with group:{wildcards.group}"
     log:
-        "logs/{sample}/transindel/{seqtype}_{group}_call.log"
+        "logs/{sample}/indel/ti_call_{seqtype}_{group}.log"
     conda:
         "../envs/transindel.yml"
     params:
@@ -75,7 +75,7 @@ rule long_indel_augment:
     message:
       "Augment long indels with group and source information and resolving alleles and removing PCR slippage using transindel on sample:{wildcards.group} with replicate:{wildcards.group}"
     log:
-        "logs/{sample}/transindel/{seqtype}_{group}_sliprem.log"
+        "logs/{sample}/indel/long_indel_augment_{seqtype}_{group}.log"
     conda:
         "../envs/manipulate_vcf.yml"
     shell:
@@ -85,12 +85,12 @@ rule long_indel_augment:
             long_indel \
             {wildcards.group} \
             {output}_infos > {log} 2>&1
-            
+
             python3 workflow/scripts/add_contigs_to_vcf.py \
             {output}_infos \
             {output}_contigs \
             resources/refs/genome.fasta >> {log} 2>&1
-            
+
             python3 workflow/scripts/slippage_removal.py \
             resources/refs/genome.fasta \
             {output}_contigs \
@@ -108,7 +108,7 @@ rule longindel_sort_and_compress:
   message:
     "Sorting and compressing long indels on sample:{wildcards.sample}"
   log:
-    "logs/{sample}/transindel/{seqtype}_{group}_longindel_sort.log"
+    "logs/{sample}/indel/longindel_sort_{seqtype}_{group}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -124,7 +124,7 @@ rule combine_longindels:
   message:
     "Combining long indels on sample:{wildcards.sample}"
   log:
-    "logs/{sample}/transindel/combine_longindels.log"
+    "logs/{sample}/indel/combine_longindels.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -143,13 +143,13 @@ checkpoint split_bam_detect_short_indels_m2:
   message:
     "Splitting bam file for somatic SNV/Indel detection with Mutect2 on recalibrated data on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-    "logs/{sample}/indel/gatk/mutect2/split_recal_{seqtype}_{group}.log"
+    "logs/{sample}/indel/split_bam_m2_{seqtype}_{group}.log"
   conda:
     "../envs/basic.yml"
   shell:
     """
       python workflow/scripts/split_bam_by_chr.py \
-          {input.bam} {output}
+          {input.bam} {output} > {log} 2>&1
     """
 
 rule index_split_bam_detect_short_indels_m2:
@@ -160,7 +160,7 @@ rule index_split_bam_detect_short_indels_m2:
   message:
     "Indexing splitted bam files for somatic SNV/Indel detection with Mutect2 on recalibrated data on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-    "logs/{sample}/indel/gatk/mutect2/index_recal_{seqtype}_{group}_{chr}.log"
+    "logs/{sample}/indel/index_split_bam_m2_{seqtype}_{group}_{chr}.log"
   conda:
     "../envs/samtools.yml"
   shell:
@@ -178,7 +178,7 @@ rule detect_short_indels_m2:
   message:
     "Detection of somatic SNVs/Indels with Mutect2 on sample:{wildcards.sample} with group:{wildcards.group} on chromosome {wildcards.chr}"
   log:
-    "logs/{sample}/indel/gatk/mutect2/m2_{seqtype}_{group}_{chr}.log",
+    "logs/{sample}/indel/detect_short_indels_m2_{seqtype}_{group}_{chr}.log",
   threads: 4
   resources:
     mem_mb=1024
@@ -196,7 +196,7 @@ rule filter_short_indels_m2:
   message:
     "Filtering somatic SNVs/Indels with FilterMutectCalls on sample:{wildcards.sample} with group:{wildcards.group} on chromosome {wildcards.chr}"
   log:
-    "logs/{sample}/indel/gatk/filtermutect/filter_{seqtype}_{group}_{chr}.log"
+    "logs/{sample}/indel/filter_short_indels_m2_{seqtype}_{group}_{chr}.log"
   params:
     extra=f"""--max-alt-allele-count 3 \
       --min-median-base-quality {config['basequal']} \
@@ -220,7 +220,7 @@ rule sort_short_indels_m2:
   message:
     "Sorting vcf file from somatic variant calling (mutect2) on recalibrated data on sample:{wildcards.sample} with group:{wildcards.group} on chromosome {wildcards.chr}"
   log:
-    "logs/{sample}/gatk/mutect2/sort_{seqtype}_{group}_{chr}.log"
+    "logs/{sample}/indel/sort_short_indels_m2_{seqtype}_{group}_{chr}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -236,7 +236,7 @@ rule index_short_indels_m2:
   message:
     "Indexing vcf file from somatic variant valling (mutect2) first round on recalibrated data on sample:{wildcards.sample} with group:{wildcards.group} on chromosome {wildcards.chr}"
   log:
-     "logs/{sample}/gatk/mutect2/index_{seqtype}_{group}_{chr}.log"
+    "logs/{sample}/indel/index_short_indels_m2_{seqtype}_{group}_{chr}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -253,7 +253,7 @@ rule merge_short_indels_m2:
   message:
     "Merging vcf files from first round of variant calling (htcaller) on original, unrecalibrated data on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-    "logs/{sample}/gatk/mutect2/merge_{seqtype}_{group}.log"
+    "logs/{sample}/indel/merge_short_indels_m2_{seqtype}_{group}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -271,14 +271,14 @@ rule index_merged_short_indels_m2:
   message:
     "Indexing vcf file from somatic variant valling (mutect2) on merged recalibrated data on sample:{wildcards.sample} with group:{wildcards.group}"
   log:
-     "logs/{sample}/gatk/mutect2/index_merged_{seqtype}_{group}.log"
+    "logs/{sample}/indel/index_merged_short_indels_m2_{seqtype}_{group}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
     """
       bcftools index -t {input} > {log} 2>&1
     """
- 
+
 rule select_short_indels_m2:
     input:
         vcf="results/{sample}/{seqtype}/indel/mutect2/{group}_variants.vcf.gz",
@@ -289,7 +289,7 @@ rule select_short_indels_m2:
     message:
       "Selecting short somatic indels with SelectVariants on sample:{wildcards.sample}"
     log:
-        "logs/{sample}/gatk/select/{seqtype}_{group}.indel.log",
+        "logs/{sample}/indel/select_short_indels_m2_{seqtype}_{group}.log",
     params:
         extra="--select-type-to-include INDEL",  # optional filter arguments, see GATK docs
         java_opts="",  # optional
@@ -305,8 +305,8 @@ rule augment_short_indels_m2:
     "results/{sample}/{seqtype}/indel/mutect2/{group}_somatic.short.indels_augmented.vcf"
   message:
     "Combining somatic short indels detected by Mutect2 on sample:{wildcards.sample}"
-  log: 
-    "logs/{sample}/combine/{seqtype}/{group}_combine_short.indels.log"
+  log:
+    "logs/{sample}/indel/augment_short_indels_m2_{seqtype}_{group}.log"
   conda:
     "../envs/manipulate_vcf.yml"
   shell:
@@ -326,7 +326,7 @@ rule sort_aug_short_indels_m2:
   message:
     "Sorting and compressing short indels on sample:{wildcards.sample}"
   log:
-    "logs/{sample}/transindel/{seqtype}_{group}_shortindel_sort.log"
+    "logs/{sample}/indel/sort_aug_short_indels_m2_{seqtype}_{group}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -340,16 +340,16 @@ rule combine_aug_short_indels_m2:
   output:
     "results/{sample}/variants/somatic.short.indels.vcf.gz"
   message:
-    "Combining long indels on sample:{wildcards.sample}"
+    "Combining short indels on sample:{wildcards.sample}"
   log:
-    "logs/{sample}/transindel/combine_longindels.log"
+    "logs/{sample}/indel/combine_short_indels.log"
   conda:
     "../envs/bcftools.yml"
   shell:
     """
       bcftools concat --naive-force -O z {input} -o - | bcftools sort -O z -o {output} > {log} 2>&1
     """
-            
+
 rule select_SNVs_m2:
   input:
     vcf="results/{sample}/{seqtype}/indel/mutect2/{group}_variants.vcf.gz",
@@ -359,7 +359,7 @@ rule select_SNVs_m2:
   message:
     "Selecting somatic SNVs with SelectVariants on sample:{wildcards.sample}"
   log:
-    "logs/{sample}/gatk/select/{seqtype}_{group}_somatic_snvs.log",
+    "logs/{sample}/indel/select_SNVs_m2_{seqtype}_{group}.log",
   params:
     extra="--select-type-to-include SNP",  # optional filter arguments, see GATK docs
     java_opts="",  # optional
@@ -375,8 +375,8 @@ rule augment_somatic_SNVs_m2:
     "results/{sample}/{seqtype}/indel/mutect2/{group}_somatic.snvs_augmented.vcf"
   message:
     "Combining somatic SNVs detected by Mutect2 on sample:{wildcards.sample}"
-  log: 
-    "logs/{sample}/indel/{seqtype}/{group}_combine_somatic_SNVs.log"
+  log:
+    "logs/{sample}/indel/augment_somatic_SNVs_m2_{seqtype}_{group}.log"
   conda:
     "../envs/manipulate_vcf.yml"
   shell:
@@ -394,9 +394,9 @@ rule sort_somatic_SNVs_m2:
   output:
     "results/{sample}/{seqtype}/indel/mutect2/{group}_somatic.snvs.vcf.gz"
   message:
-    "Sorting and compressing short indels on sample:{wildcards.sample}"
+    "Sorting and compressing somatic SNVs on sample:{wildcards.sample}"
   log:
-    "logs/{sample}/transindel/{seqtype}_{group}_SNVs_sort.log"
+    "logs/{sample}/indel/sort_somatic_SNVs_m2_{seqtype}_{group}.log"
   conda:
     "../envs/bcftools.yml"
   shell:
@@ -410,9 +410,9 @@ rule combine_somatic_SNVs_m2:
   output:
     "results/{sample}/variants/somatic.snvs.vcf.gz"
   message:
-    "Combining long indels on sample:{wildcards.sample}"
+    "Combining somatic SNVs on sample:{wildcards.sample}"
   log:
-    "logs/{sample}/transindel/combine_somatic_SNVs.log"
+    "logs/{sample}/indel/combine_somatic_SNVs.log"
   conda:
     "../envs/bcftools.yml"
   shell:

--- a/workflow/rules/prelim.smk
+++ b/workflow/rules/prelim.smk
@@ -7,9 +7,9 @@ rule create_tmp_folder:
   conda:
     "../envs/basic.yml"
   log:
-    "logs/prelim.log"
+    "logs/ref/create_tmp_folder.log"
   shell:
     """
-      mkdir -p {output}
+      mkdir -p {output} > {log} 2>&1
     """
 

--- a/workflow/rules/preproc.smk
+++ b/workflow/rules/preproc.smk
@@ -7,7 +7,7 @@ rule fastqc_single_end:
     params:
         extra = "--quiet"
     log:
-        "logs/{sample}/fastqc/{seqtype}_{group}.log"
+        "logs/{sample}/preproc/fastqc_single_end_{seqtype}_{group}.log"
     threads: 1
     resources:
         mem_mb = 1024
@@ -24,7 +24,7 @@ rule preproc_single_end:
     html="results/{sample}/{seqtype}/reads/{group}_preproc_report.html",
     json="results/{sample}/{seqtype}/reads/{group}_preproc_report.json"
   log:
-    "logs/{sample}/fastp/{seqtype}_{group}.log"
+    "logs/{sample}/preproc/fastp_single_end_{seqtype}_{group}.log"
   params:
     adapters="",
     extra=""
@@ -41,7 +41,7 @@ rule fastqc_forward:
     params:
         extra = ""
     log:
-        "logs/{sample}/fastqc/{seqtype}_{group}_fwd_raw.log"
+        "logs/{sample}/preproc/fastqc_forward_{seqtype}_{group}.log"
     threads: 1
     resources:
         mem_mb = 1024
@@ -57,7 +57,7 @@ rule fastqc_reverse:
     params:
         extra = "--quiet"
     log:
-        "logs/{sample}/fastqc/{seqtype}_{group}_fwd_raw.log"
+        "logs/{sample}/preproc/fastqc_reverse_{seqtype}_{group}.log"
     threads: 1
     resources:
         mem_mb = 1024
@@ -70,7 +70,7 @@ rule preproc_paired_end:
       qc1="results/{sample}/{seqtype}/qualitycontrol/{group}_R1_fastqc_raw.html",
       qc2="results/{sample}/{seqtype}/qualitycontrol/{group}_R2_fastqc_raw.html"
     output:
-        trimmed=["results/{sample}/{seqtype}/reads/{group}_R1_preproc.fq.gz", 
+        trimmed=["results/{sample}/{seqtype}/reads/{group}_R1_preproc.fq.gz",
                  "results/{sample}/{seqtype}/reads/{group}_R2_preproc.fq.gz"],
         unpaired1="results/{sample}/{seqtype}/reads/{group}_R1_preproc_unpaired.fq.gz",
         unpaired2="results/{sample}/{seqtype}/reads/{group}_R2_preproc_unpaired.fq.gz",
@@ -78,11 +78,11 @@ rule preproc_paired_end:
         html="results/{sample}/{seqtype}/reads/{group}_preproc_report.html",
         json="results/{sample}/{seqtype}/reads/{group}_preproc_report.json",
     log:
-        "logs/{sample}/fastp/{seqtype}_{group}.log"
+        "logs/{sample}/preproc/fastp_paired_end_{seqtype}_{group}.log"
     params:
       dapters="",
       extra=lambda wildcards: "-u 100 -e {0} -l {1} {2} ".format(
-          config['basequal'], 
+          config['basequal'],
           config['preproc']['minlen'],
           "-3 --cut_tail_window_size {} cut_tail_mean_quality {}".format(
               config['preproc']['slidingwindow']['wsize'],
@@ -103,7 +103,7 @@ rule fastqc_forward_after:
     params:
         extra = ""
     log:
-        "logs/{sample}/fastqc/{seqtype}_{group}_fwd.log"
+        "logs/{sample}/preproc/fastqc_forward_after_{seqtype}_{group}.log"
     threads: 1
     resources:
         mem_mb = 1024
@@ -120,11 +120,10 @@ rule fastqc_reverse_after:
     params:
         extra = "--quiet"
     log:
-        "logs/{sample}/fastqc/{seqtype}_{group}_rev.log"
+        "logs/{sample}/preproc/fastqc_reverse_after_{seqtype}_{group}.log"
     threads: 1
     resources:
         mem_mb = 1024
     wrapper:
         "v2.2.1/bio/fastqc"
-
 

--- a/workflow/rules/prioritization.smk
+++ b/workflow/rules/prioritization.smk
@@ -4,13 +4,13 @@ rule download_mhcI_ba_tools:
   message:
     "Downloading MHC I prediction tools"
   log:
-    "logs/download_mhc-I_ba_tools.log"
+    "logs/download/mhcI_ba_tools.log"
   conda:
     "../envs/basic.yml"
   shell:
     """
-      curl -L -o - https://downloads.iedb.org/tools/mhci/3.1.4/IEDB_MHC_I-3.1.4.tar.gz \
-          | tar xz -C workflow/scripts/
+      (curl -L -o - https://downloads.iedb.org/tools/mhci/3.1.4/IEDB_MHC_I-3.1.4.tar.gz \
+          | tar xz -C workflow/scripts/) > {log} 2>&1
     """
 
 rule download_mhcII_ba_tools:
@@ -19,12 +19,12 @@ rule download_mhcII_ba_tools:
   message:
     "Downloading MHC II prediction tools"
   log:
-    "logs/download_mhc-II_ba_tools.log"
+    "logs/download/mhcII_ba_tools.log"
   conda:
     "../envs/basic.yml"
   shell:
     """
-      curl -L -o - https://downloads.iedb.org/tools/mhcii/3.1.12/IEDB_MHC_II-3.1.12.tar.gz \
+      (curl -L -o - https://downloads.iedb.org/tools/mhcii/3.1.12/IEDB_MHC_II-3.1.12.tar.gz \
           | tar xz -C workflow/scripts/
       cp misc/mhc_ii/methods/netmhciipan-3.2-executable/netmhciipan_3_2_executable/netmhciipan_python_interface.py \
           workflow/scripts/mhc_ii/methods/netmhciipan-3.2-executable/netmhciipan_3_2_executable/
@@ -33,7 +33,7 @@ rule download_mhcII_ba_tools:
       cp misc/mhc_ii/methods/netmhciipan-4.2-executable/netmhciipan_4_2_executable/netmhciipan_python_interface.py \
           workflow/scripts/mhc_ii/methods/netmhciipan-4.2-executable/netmhciipan_4_2_executable/
       cp misc/mhc_ii/methods/netmhciipan-4.3-executable/netmhciipan_4_3_executable/netmhciipan_python_interface.py \
-          workflow/scripts/mhc_ii/methods/netmhciipan-4.3-executable/netmhciipan_4_3_executable/
+          workflow/scripts/mhc_ii/methods/netmhciipan-4.3-executable/netmhciipan_4_3_executable/) > {log} 2>&1
     """
 
 rule download_prediction_binding_affinity_tools:
@@ -42,13 +42,13 @@ rule download_prediction_binding_affinity_tools:
   message:
     "Downloading immunogenicity prediction tools"
   log:
-    "logs/download_immunogenicity_tools.log"
+    "logs/download/immunogenicity_tools.log"
   conda:
     "../envs/basic.yml"
   shell:
     """
-      curl -L -o - https://downloads.iedb.org/tools/immunogenicity/3.0/IEDB_Immunogenicity-3.0.tar.gz \
-          | tar xz -C workflow/scripts/
+      (curl -L -o - https://downloads.iedb.org/tools/immunogenicity/3.0/IEDB_Immunogenicity-3.0.tar.gz \
+          | tar xz -C workflow/scripts/) > {log} 2>&1
     """
 
 rule prioritization:
@@ -76,7 +76,7 @@ rule prioritization:
   conda:
     "../envs/prioritization.yml"
   log:
-    "logs/prioritization/{sample}.log"
+    "logs/{sample}/prioritization/prioritization.log"
   threads: config["threads"]
   params:
     mhc_class = f"""{config["prioritization"]["class"]}""",

--- a/workflow/rules/quantification.smk
+++ b/workflow/rules/quantification.smk
@@ -5,7 +5,7 @@ rule countfeatures:
   output:
     "results/{sample}/{seqtype}/quantification/{group}_counts.txt"
   log:
-    "logs/{sample}/featurecounts/{seqtype}_{group}.log"
+    "logs/{sample}/quantification/countfeatures_{seqtype}_{group}.log"
   threads: 2
   conda:
     "../envs/subread.yml"
@@ -15,7 +15,7 @@ rule countfeatures:
     """
       python workflow/scripts/quantification/featurecounts_wrapper.py \
           {input.sample} {output} {input.annotation_file} \
-          {params.mapq} {threads} 
+          {params.mapq} {threads} > {log} 2>&1
     """
 
 # merges the count tables from all samples into single table (calculates TPM)

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -8,17 +8,17 @@ rule get_genome:
   conda:
     "../envs/basic.yml"
   log:
-    "logs/get-genome.log",
+    "logs/ref/get_genome.log",
   params:
     release=f"""{config['reference']['release']}"""
   shell:
     """
-      curl -L -o {output.genome}.gz https://ftp.ensembl.org/pub/release-{params.release}/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz 
+      (curl -L -o {output.genome}.gz https://ftp.ensembl.org/pub/release-{params.release}/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz
       gzip -d {output.genome}.gz
-      curl -L -o {output.annotation}.gz https://ftp.ensembl.org/pub/release-{params.release}/gtf/homo_sapiens/Homo_sapiens.GRCh38.{params.release}.gtf.gz 
+      curl -L -o {output.annotation}.gz https://ftp.ensembl.org/pub/release-{params.release}/gtf/homo_sapiens/Homo_sapiens.GRCh38.{params.release}.gtf.gz
       gzip -d {output.annotation}.gz
       curl -L -o {output.peptide}.gz https://ftp.ensembl.org/pub/release-{params.release}/fasta/homo_sapiens/pep/Homo_sapiens.GRCh38.pep.all.fa.gz
-      gzip -d {output.peptide}.gz
+      gzip -d {output.peptide}.gz) > {log} 2>&1
     """
 
 rule mod_genome:
@@ -33,19 +33,19 @@ rule mod_genome:
   conda:
     "../envs/basic.yml"
   log:
-    "logs/mod-genome.log"
+    "logs/ref/mod_genome.log"
   params:
     nonchr=f"""{int(config['reference']['nonchr'])}"""
   shell:
     """
-        python3 workflow/scripts/reference/modify_ensembl_header.py {input.genome} {output.genome} {input.annotation} {output.annotation} {params.nonchr}
+        python3 workflow/scripts/reference/modify_ensembl_header.py {input.genome} {output.genome} {input.annotation} {output.annotation} {params.nonchr} > {log} 2>&1
     """
 
 # this forces to redownload the reference on each execution
 ##      rm resources/refs/genome_tmp.fasta
 #      rm resources/refs/genome_tmp.gtf
 
-rule genome_index: 
+rule genome_index:
   input:
     "resources/refs/genome.fasta"
   output:
@@ -53,7 +53,7 @@ rule genome_index:
   message:
     "Create index of reference genome"
   log:
-    "logs/samtools/index_genome.log",
+    "logs/ref/genome_index.log",
   params:
     extra="",  # optional params string
   wrapper:
@@ -67,12 +67,12 @@ rule annotation_sort_bgzip:
   message:
     "Sort of bgzip the annotations file"
   log:
-    "logs/bgzip_annotation"
+    "logs/ref/annotation_sort_bgzip.log"
   conda:
     "../envs/basic.yml"
   shell:
     """
-      (grep "^#" {input}; grep -v "^#" {input} | sort -t"`printf '\t'`" -k1,1 -k4,4n) | bgzip > {output}
+      ((grep "^#" {input}; grep -v "^#" {input} | sort -t"`printf '\t'`" -k1,1 -k4,4n) | bgzip > {output}) 2> {log}
     """
 
 rule tabix:
@@ -81,7 +81,7 @@ rule tabix:
   output:
       "resources/refs/genome.gtf.gz.csi",
   log:
-      "logs/tabix/annotation.log",
+      "logs/ref/tabix.log",
   params:
       # pass arguments to tabix (e.g. index a vcf)
       "-C -p gff",
@@ -99,7 +99,7 @@ rule star_index:
   params:
       extra="--genomeSAindexNbases 5 ",
   log:
-      "logs/star/create_star_index.log",
+      "logs/ref/star_index.log",
   wrapper:
       "v1.26.0/bio/star/index"
 
@@ -109,7 +109,7 @@ rule bwa_index:
   output:
     idx = multiext("resources/refs/bwa/genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
   log:
-    "logs/bwa_index.log",
+    "logs/ref/bwa_index.log",
   params:
     algorithm="bwtsw",
   wrapper:
@@ -124,7 +124,7 @@ rule create_sequence_dictionary:
   message:
     "Create sequence dictionary of reference genome"
   log:
-    "logs/picard/create_dict.log"
+    "logs/ref/create_sequence_dictionary.log"
   params:
     extra="",  # optional: extra arguments for picard.
   resources:
@@ -139,12 +139,12 @@ rule get_hla_info:
   message:
     "Download full resolution HLA information"
   log:
-    "logs/get_hla_info.log"
+    "logs/ref/get_hla_info.log"
   conda:
     "../envs/basic.yml"
   shell:
     """
-      curl -L -o {output} https://ftp.ebi.ac.uk/pub/databases/ipd/imgt/hla/hla_gen.fasta
+      curl -L -o {output} https://ftp.ebi.ac.uk/pub/databases/ipd/imgt/hla/hla_gen.fasta > {log} 2>&1
     """
 
 rule create_hla_idx_bowtie:
@@ -163,7 +163,7 @@ rule create_hla_idx_bowtie:
   message:
     "Create bowtie index of HLA reference"
   log:
-    "logs/bowtie2/create_hla_idx.log"
+    "logs/ref/create_hla_idx_bowtie.log"
   params:
       extra="",  # optional parameters
   threads: 8


### PR DESCRIPTION
## Summary

### Refactored

- **Consistent log path convention**: All 138 rules now follow a uniform structure — `logs/ref/` and `logs/download/` for global rules, `logs/{sample}/{stage}/` for per-sample rules, with stages matching pipeline modules (preproc, align, hlatyping, indel, germline, altsplicing, exitron, genefusion, custom, annotation, prioritization, quantification)
- **Fix missing log redirects**: ~40 shell rules had `log:` directives but never redirected output to `{log}`, producing empty log files. All now use `> {log} 2>&1` (or `2> {log}` where stdout goes to a file)
- **Fix log path bugs**: `.logs` typo, missing `.log` extension, duplicate paths between altsplicing/exitron combine rules, SE rule logging to PE path, wrong log path in combine_aug_short_indels_m2
- **Fix markdup log overwrite**: `rnaseq_postproc_markdup` second command used `>` instead of `>>`, silently overwriting the first command's log output
- **Fix incorrect rule messages**: Several final-round germline rules incorrectly said "first round" in their `message:` directive

## QC

- [x] I, as a human being, have checked each line of code
- [x] Run `snakemake --lint` to verify no syntax errors
- [x] Dry run (`snakemake -n`) to verify DAG is unchanged
- [x] Run a small test to confirm log files are created and populated in the new paths

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized log file organization across all pipeline stages for better accessibility
  * Enhanced log capture to ensure all command output is properly recorded
  * Consolidated log naming conventions for consistency and clarity
  * Fixed log path inconsistencies and naming mismatches throughout the workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->