### PR TITLE
Fix malformed params string and string comparison bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Batch binding affinity predictions**: Split large FASTA files into batches of 500 sequences before sending to NetMHCpan/NetMHCIIpan, preventing indefinite hangs on large inputs (e.g., 3,700+ alternative splicing events). Also fixed `as_completed` loop running outside the executor context and added detailed progress logging. ([#58](https://github.com/ylab-hi/ScanNeo2/pull/58))
+- **Fix malformed params and string comparisons**: Fixed `align.smk` params that passed a literal string instead of the config MAPQ value, and replaced `is not ""` with `!=` across `compile.py` and `merge_counttables.py` (future Python 3.12 SyntaxError). ([#61](https://github.com/ylab-hi/ScanNeo2/issues/61), [#72](https://github.com/ylab-hi/ScanNeo2/pull/72))
 
 ### Refactored
 

--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -132,7 +132,7 @@ rule rnaseq_postproc_fixmate:
     "logs/{sample}/align/rnaseq_postproc_fixmate_{group}.log"
   threads: 4
   params:
-    mapq="--min-MQ config['mapq']"
+    mapq=f"--min-MQ {config['mapq']}"
   shell:
     """
       samtools view -h -F 4 {params.mapq} {input} -o - \

--- a/workflow/scripts/prioritization/compile.py
+++ b/workflow/scripts/prioritization/compile.py
@@ -17,19 +17,19 @@ class Compile:
         self.combined = ["",""] # combined neoepitopes from different types
         self.options = options
 
-        if options.SNVs is not "":
+        if options.SNVs != "":
             self.prioritize(options.SNVs, options, "somatic.snvs")
-        if options.indels is not "":
+        if options.indels != "":
             self.prioritize(options.indels, options, "somatic.short.indels")
-        if options.long_indels is not "":
+        if options.long_indels != "":
             self.prioritize(options.long_indels, options, "long.indels")
-        if options.exitrons is not "":
+        if options.exitrons != "":
             self.prioritize(options.exitrons, options, "exitrons")
-        if options.altsplicing is not "":
+        if options.altsplicing != "":
             self.prioritize(options.altsplicing, options, "altsplicing")
-        if options.custom is not "":
+        if options.custom != "":
             self.prioritize(options.custom, options, "custom")
-        if options.fusions is not "":
+        if options.fusions != "":
             self.prioritize(options.fusions, options, "fusions")
 
         # combine neoepitopes

--- a/workflow/scripts/quantification/merge_counttables.py
+++ b/workflow/scripts/quantification/merge_counttables.py
@@ -11,7 +11,7 @@ def main():
     """make sure this works if the input is empty - this happens when the user
     does not provide sequencing files (and instead works on provided vcf files)"""
                                                    
-    if options.input is not "":
+    if options.input != "":
         samples = options.input.split(" ")
         counts = {}
         groups = []


### PR DESCRIPTION
## Summary

### Fixed

- **Fix malformed params in align.smk**: `params: mapq="--min-MQ config['mapq']"` was a literal string — `config['mapq']` was never interpolated, so samtools received the text `config['mapq']` instead of the actual MAPQ value. Changed to f-string.
- **Fix `is not ""` string comparisons**: Replaced 8 instances of `is not ""` with `!=` in `compile.py` (7) and `merge_counttables.py` (1). Using `is` for string comparison is unreliable (depends on interning) and becomes a SyntaxError in Python 3.12+.

Closes #61

## QC

- [x] I, as a human being, have checked each line of code
- [x] CI passes (linting, formatting)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration interpolation so alignment thresholds are applied correctly
  * Corrected input-detection logic for optional prioritization modules
  * Improved input validation for count-table merging and quantification steps

* **Documentation**
  * Added a changelog entry documenting the above fixes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->