### PR TITLE
Replace shell=True subprocess calls with list-based arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Replace shell=True subprocess calls with list-based arguments**: Refactored 5 wrapper scripts (`optitype_wrapper`, `finalize_mhcII_input`, `get_readgroups`, `compile`, `featurecounts_wrapper`) to use list-based `subprocess.run(..., check=True)` instead of shell=True string commands. Eliminates path-with-spaces breakage, surfaces tool stderr, and lets failures fail loudly. `compile.combine_neoepitopes` rewritten to concatenate files in Python; `get_readgroups.scan_bamfile` filters `@RG` headers in Python instead of piping samtools to grep. ([#62](https://github.com/ylab-hi/ScanNeo2/issues/62), [#74](https://github.com/ylab-hi/ScanNeo2/pull/74))
+- **Fix dead VQSR download URLs and add --fail to all curl rules**: The Broad's hg38 GATK resources moved from `genomics-public-data/resources/broad/hg38/v0/` (now access-denied) to `gcp-public-data--broad-references/hg38/v0/`; the old URLs caused `curl` to silently save a 298-byte XML 403 page as the VCF, and GATK VariantRecalibrator then failed with "no suitable codecs found". Updated the 4 affected URLs and added `--fail` to every curl call across 5 rule files (23 invocations) so download failures surface at the download step. Contributes to [#63](https://github.com/ylab-hi/ScanNeo2/issues/63) (`--fail` half complete; checksum verification still open). ([#74](https://github.com/ylab-hi/ScanNeo2/pull/74))
 
 ## [0.3.8] - 2026-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Replace shell=True subprocess calls with list-based arguments**: Refactored 5 wrapper scripts (`optitype_wrapper`, `finalize_mhcII_input`, `get_readgroups`, `compile`, `featurecounts_wrapper`) to use list-based `subprocess.run(..., check=True)` instead of shell=True string commands. Eliminates path-with-spaces breakage, surfaces tool stderr, and lets failures fail loudly. `compile.combine_neoepitopes` rewritten to concatenate files in Python; `get_readgroups.scan_bamfile` filters `@RG` headers in Python instead of piping samtools to grep. ([#62](https://github.com/ylab-hi/ScanNeo2/issues/62), [#74](https://github.com/ylab-hi/ScanNeo2/pull/74))
+
 ## [0.3.8] - 2026-03-26
 
 ### Fixed

--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -12,9 +12,9 @@ rule download_vep_plugins:
   shell:
     """
       (mkdir -p resources/vep/plugins/
-      curl -L -o {output}/NMD.pm https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/{params.release}/NMD.pm
-      curl -L -o {output}/Downstream.pm https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/{params.release}/Downstream.pm
-      curl -L -o {output}/Wildtype.pm https://raw.githubusercontent.com/griffithlab/pVAC-Seq/master/pvacseq/VEP_plugins/Wildtype.pm) > {log} 2>&1
+      curl --fail -L -o {output}/NMD.pm https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/{params.release}/NMD.pm
+      curl --fail -L -o {output}/Downstream.pm https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/{params.release}/Downstream.pm
+      curl --fail -L -o {output}/Wildtype.pm https://raw.githubusercontent.com/griffithlab/pVAC-Seq/master/pvacseq/VEP_plugins/Wildtype.pm) > {log} 2>&1
     """
 
 rule download_vep_cache:
@@ -31,7 +31,7 @@ rule download_vep_cache:
   shell:
     """
       (mkdir -p {output}
-      curl -L -C - \
+      curl --fail -L -C - \
           --retry 10 \
           --retry-delay 10 \
           --retry-all-errors \

--- a/workflow/rules/germline.smk
+++ b/workflow/rules/germline.smk
@@ -20,16 +20,16 @@ rule get_gatk_vqsr_training_sets:
     "../envs/basic.yml"
   shell:
     """
-    (curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/hapmap_3.3.hg38.vcf.gz -o resources/vqsr/hapmap_3.3.hg38.vcf.gz
-    curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/hapmap_3.3.hg38.vcf.gz.tbi -o resources/vqsr/hapmap_3.3.hg38.vcf.gz.tbi
-    curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/1000G_omni2.5.hg38.vcf.gz -o resources/vqsr/1000G_omni2.5.hg38.vcf.gz
-    curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/1000G_omni2.5.hg38.vcf.gz.tbi -o resources/vqsr/1000G_omni2.5.hg38.vcf.gz.tbi
-    curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz -o resources/vqsr/1000G_phase1.snps.high_confidence.hg38.vcf.gz
-    curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi -o resources/vqsr/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi
-    curl -L https://ftp.ncbi.nlm.nih.gov/snp/organisms/human_9606_b150_GRCh38p7/VCF/GATK/00-common_all.vcf.gz  -o resources/vqsr/dbSNP_b150.vcf.gz
-    curl -L https://ftp.ncbi.nlm.nih.gov/snp/organisms/human_9606_b150_GRCh38p7/VCF/GATK/00-common_all.vcf.gz.tbi  -o resources/vqsr/dbSNP_b150.vcf.gz.tbi
-    curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz -o resources/vqsr/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz
-    curl -L https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi -o resources/vqsr/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi) > {log} 2>&1
+    (curl --fail -L https://storage.googleapis.com/gcp-public-data--broad-references/hg38/v0/hapmap_3.3.hg38.vcf.gz -o resources/vqsr/hapmap_3.3.hg38.vcf.gz
+    curl --fail -L https://storage.googleapis.com/gcp-public-data--broad-references/hg38/v0/hapmap_3.3.hg38.vcf.gz.tbi -o resources/vqsr/hapmap_3.3.hg38.vcf.gz.tbi
+    curl --fail -L https://storage.googleapis.com/gcp-public-data--broad-references/hg38/v0/1000G_omni2.5.hg38.vcf.gz -o resources/vqsr/1000G_omni2.5.hg38.vcf.gz
+    curl --fail -L https://storage.googleapis.com/gcp-public-data--broad-references/hg38/v0/1000G_omni2.5.hg38.vcf.gz.tbi -o resources/vqsr/1000G_omni2.5.hg38.vcf.gz.tbi
+    curl --fail -L https://storage.googleapis.com/gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz -o resources/vqsr/1000G_phase1.snps.high_confidence.hg38.vcf.gz
+    curl --fail -L https://storage.googleapis.com/gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi -o resources/vqsr/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi
+    curl --fail -L https://ftp.ncbi.nlm.nih.gov/snp/organisms/human_9606_b150_GRCh38p7/VCF/GATK/00-common_all.vcf.gz  -o resources/vqsr/dbSNP_b150.vcf.gz
+    curl --fail -L https://ftp.ncbi.nlm.nih.gov/snp/organisms/human_9606_b150_GRCh38p7/VCF/GATK/00-common_all.vcf.gz.tbi  -o resources/vqsr/dbSNP_b150.vcf.gz.tbi
+    curl --fail -L https://storage.googleapis.com/gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz -o resources/vqsr/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz
+    curl --fail -L https://storage.googleapis.com/gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi -o resources/vqsr/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi) > {log} 2>&1
     """
 
 # do a first round of variant calling on original, unrecalibrated data

--- a/workflow/rules/hlatyping_prep.smk
+++ b/workflow/rules/hlatyping_prep.smk
@@ -11,8 +11,8 @@ rule get_mhcI_hla_panel:
     "logs/ref/get_mhcI_hla_panel.log"
   shell:
     """
-      (curl -o {output.dna} https://raw.githubusercontent.com/FRED-2/OptiType/v1.3.5/data/hla_reference_dna.fasta
-      curl -o {output.rna} https://raw.githubusercontent.com/FRED-2/OptiType/v1.3.5/data/hla_reference_rna.fasta) > {log} 2>&1
+      (curl --fail -o {output.dna} https://raw.githubusercontent.com/FRED-2/OptiType/v1.3.5/data/hla_reference_dna.fasta
+      curl --fail -o {output.rna} https://raw.githubusercontent.com/FRED-2/OptiType/v1.3.5/data/hla_reference_rna.fasta) > {log} 2>&1
     """
 
 rule index_mhcI_hla_panel:

--- a/workflow/rules/prioritization.smk
+++ b/workflow/rules/prioritization.smk
@@ -9,7 +9,7 @@ rule download_mhcI_ba_tools:
     "../envs/basic.yml"
   shell:
     """
-      (curl -L -o - https://downloads.iedb.org/tools/mhci/3.1.4/IEDB_MHC_I-3.1.4.tar.gz \
+      (curl --fail -L -o - https://downloads.iedb.org/tools/mhci/3.1.4/IEDB_MHC_I-3.1.4.tar.gz \
           | tar xz -C workflow/scripts/) > {log} 2>&1
     """
 
@@ -24,7 +24,7 @@ rule download_mhcII_ba_tools:
     "../envs/basic.yml"
   shell:
     """
-      (curl -L -o - https://downloads.iedb.org/tools/mhcii/3.1.12/IEDB_MHC_II-3.1.12.tar.gz \
+      (curl --fail -L -o - https://downloads.iedb.org/tools/mhcii/3.1.12/IEDB_MHC_II-3.1.12.tar.gz \
           | tar xz -C workflow/scripts/
       cp misc/mhc_ii/methods/netmhciipan-3.2-executable/netmhciipan_3_2_executable/netmhciipan_python_interface.py \
           workflow/scripts/mhc_ii/methods/netmhciipan-3.2-executable/netmhciipan_3_2_executable/
@@ -47,7 +47,7 @@ rule download_prediction_binding_affinity_tools:
     "../envs/basic.yml"
   shell:
     """
-      (curl -L -o - https://downloads.iedb.org/tools/immunogenicity/3.0/IEDB_Immunogenicity-3.0.tar.gz \
+      (curl --fail -L -o - https://downloads.iedb.org/tools/immunogenicity/3.0/IEDB_Immunogenicity-3.0.tar.gz \
           | tar xz -C workflow/scripts/) > {log} 2>&1
     """
 

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -13,11 +13,11 @@ rule get_genome:
     release=f"""{config['reference']['release']}"""
   shell:
     """
-      (curl -L -o {output.genome}.gz https://ftp.ensembl.org/pub/release-{params.release}/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz
+      (curl --fail -L -o {output.genome}.gz https://ftp.ensembl.org/pub/release-{params.release}/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz
       gzip -d {output.genome}.gz
-      curl -L -o {output.annotation}.gz https://ftp.ensembl.org/pub/release-{params.release}/gtf/homo_sapiens/Homo_sapiens.GRCh38.{params.release}.gtf.gz
+      curl --fail -L -o {output.annotation}.gz https://ftp.ensembl.org/pub/release-{params.release}/gtf/homo_sapiens/Homo_sapiens.GRCh38.{params.release}.gtf.gz
       gzip -d {output.annotation}.gz
-      curl -L -o {output.peptide}.gz https://ftp.ensembl.org/pub/release-{params.release}/fasta/homo_sapiens/pep/Homo_sapiens.GRCh38.pep.all.fa.gz
+      curl --fail -L -o {output.peptide}.gz https://ftp.ensembl.org/pub/release-{params.release}/fasta/homo_sapiens/pep/Homo_sapiens.GRCh38.pep.all.fa.gz
       gzip -d {output.peptide}.gz) > {log} 2>&1
     """
 
@@ -144,7 +144,7 @@ rule get_hla_info:
     "../envs/basic.yml"
   shell:
     """
-      curl -L -o {output} https://ftp.ebi.ac.uk/pub/databases/ipd/imgt/hla/hla_gen.fasta > {log} 2>&1
+      curl --fail -L -o {output} https://ftp.ebi.ac.uk/pub/databases/ipd/imgt/hla/hla_gen.fasta > {log} 2>&1
     """
 
 rule create_hla_idx_bowtie:

--- a/workflow/scripts/genotyping/finalize_mhcII_input.py
+++ b/workflow/scripts/genotyping/finalize_mhcII_input.py
@@ -35,13 +35,16 @@ def split(infile, out_fwd, out_rev):
     print(f"Input file: {infile}")
     print(f"Reverse reads: {out_rev}")
     print(f"Forward reads: {out_fwd}")
-    call = "samtools fastq"
-    call += " -1 " + out_fwd + " -2 " + out_rev
-    call += " -0 /dev/null" # discard unpaired reads
-    call += " -s /dev/null" # discard singletons
-    call += " " + infile
-    print(call)
-    subprocess.call(call, shell=True)
+    cmd = [
+        "samtools", "fastq",
+        "-1", out_fwd,
+        "-2", out_rev,
+        "-0", "/dev/null",  # discard unpaired reads
+        "-s", "/dev/null",  # discard singletons
+        infile,
+    ]
+    print(" ".join(cmd))
+    subprocess.run(cmd, check=True)
     print("Done.")
 
 def main():

--- a/workflow/scripts/genotyping/optitype_wrapper.py
+++ b/workflow/scripts/genotyping/optitype_wrapper.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import subprocess
+from pathlib import Path
 
 """
     Usage:
@@ -8,36 +9,41 @@ import subprocess
 """
 
 def main():
-    inbams = sys.argv[1]
+    inbams_arg = sys.argv[1]
     nartype = "dna" if sys.argv[2] == "DNA" else "rna"
     prefix = sys.argv[3]
     outpath = sys.argv[4]
 
-    for filename in inbams.split(' '):
+    inbams = inbams_arg.split()
+
+    for filename in inbams:
         if not os.path.exists(filename + '.bai'):
             print("Indexing BAM file: " + filename)
-            samtools_idx = subprocess.Popen("samtools index " + 
-                                            filename, shell=True)
+            subprocess.run(["samtools", "index", filename], check=True)
 
-    # check if input file is not empty (using samtools)
     try:
-        samtools = subprocess.Popen("samtools view -c " + inbams.split(' ')[0] + " 2>/dev/null", 
-                                    stdout=subprocess.PIPE, shell=True)
+        result = subprocess.run(
+            ["samtools", "view", "-c", inbams[0]],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            universal_newlines=True, check=True)
 
-        if int(samtools.communicate()[0]) < 10:
-            print("Input BAM file: " + inbams + " is empty")
-            # create an empty output file
-            pdf = subprocess.Popen("touch " + outpath + prefix + "_coverage_plot.pdf", shell=True)
-            tsv = subprocess.Popen("touch " + outpath + prefix + "_result.tsv", shell=True)
+        if int(result.stdout.strip()) < 10:
+            print("Input BAM file: " + inbams_arg + " is empty")
+            Path(outpath + prefix + "_coverage_plot.pdf").touch()
+            Path(outpath + prefix + "_result.tsv").touch()
         else:
-            # call optitype 
-            optitype_call = "OptiTypePipeline.py --input " + inbams + " --outdir " + outpath + " --prefix " + prefix + " --" + nartype + " -v"
-            print(optitype_call)
-            os.system(optitype_call)
-#            optitype = subprocess.Popen(optitype_call, shell=True)
-
+            optitype_cmd = [
+                "OptiTypePipeline.py",
+                "--input", *inbams,
+                "--outdir", outpath,
+                "--prefix", prefix,
+                "--" + nartype,
+                "-v",
+            ]
+            print(" ".join(optitype_cmd))
+            subprocess.run(optitype_cmd, check=True)
 
     except subprocess.CalledProcessError as e:
-        print("samtools failed")
+        print("samtools failed: " + str(e))
 
 main()

--- a/workflow/scripts/genotyping/optitype_wrapper.py
+++ b/workflow/scripts/genotyping/optitype_wrapper.py
@@ -45,5 +45,6 @@ def main():
 
     except subprocess.CalledProcessError as e:
         print("samtools failed: " + str(e))
+        raise
 
 main()

--- a/workflow/scripts/get_readgroups.py
+++ b/workflow/scripts/get_readgroups.py
@@ -14,12 +14,16 @@ class ReadGroups:
         # self.readgroups = {}
     def scan_bamfile(self, bamfile):
         try:
-            rg_header = subprocess.Popen("samtools view -H " + bamfile + 
-                " | grep ^@RG", stdout=subprocess.PIPE, shell=True)
+            result = subprocess.run(
+                ["samtools", "view", "-H", bamfile],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                universal_newlines=True, check=True)
 
-            for rg_objects in rg_header.stdout:
+            for header_line in result.stdout.splitlines():
+                if not header_line.startswith("@RG"):
+                    continue
                 entry = ['unknown','unknown','unknown','unknown']
-                line = rg_objects.decode("utf-8").rstrip().split("\t")
+                line = header_line.rstrip().split("\t")
                 for tag in line:
                     if tag.startswith("ID"):
                         rg_id = str(tag.split(":")[1])
@@ -35,7 +39,7 @@ class ReadGroups:
                 self.add_readgroup(rg_id,entry)
 
         except subprocess.CalledProcessError as e:
-            print("samtools failed")
+            print(f"samtools failed: {e.stderr}")
 
 
     def add_readgroup(self, rg_id, tags):

--- a/workflow/scripts/get_readgroups.py
+++ b/workflow/scripts/get_readgroups.py
@@ -40,6 +40,7 @@ class ReadGroups:
 
         except subprocess.CalledProcessError as e:
             print(f"samtools failed: {e.stderr}")
+            raise
 
 
     def add_readgroup(self, rg_id, tags):

--- a/workflow/scripts/prioritization/compile.py
+++ b/workflow/scripts/prioritization/compile.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import configargparse
-import subprocess
 
 # classes
 import reference
@@ -14,7 +13,8 @@ import filtering
 
 class Compile:
     def __init__(self, options):
-        self.combined = ["",""] # combined neoepitopes from different types
+        # per-class lists of neoepitope files to concatenate at the end
+        self.combined = {"mhc-I": [], "mhc-II": []}
         self.options = options
 
         if options.SNVs != "":
@@ -32,11 +32,20 @@ class Compile:
         if options.fusions != "":
             self.prioritize(options.fusions, options, "fusions")
 
-        # combine neoepitopes
-        if self.combined[0] != "":
-            subprocess.run(self.combined[0], shell=True)
-        if self.combined[1] != "":
-            subprocess.run(self.combined[1], shell=True)
+        # combine neoepitopes per MHC class: take header from the first file,
+        # strip header from subsequent ones.
+        for mhc_class, files in self.combined.items():
+            if not files:
+                continue
+            outfile = os.path.join(
+                options.output_dir, f"{mhc_class}_neoepitopes_all.txt")
+            with open(outfile, "w") as out_fh:
+                for idx, fname in enumerate(files):
+                    with open(fname, "r") as in_fh:
+                        if idx > 0:
+                            next(in_fh, None)
+                        for line in in_fh:
+                            out_fh.write(line)
 
     def prioritize(self, inputfile, options, vartype):
         if (vartype == "somatic.snvs" or 
@@ -106,21 +115,7 @@ class Compile:
 
 
     def combine_neoepitopes(self, neoepitopes_file, mhc_class):
-        if mhc_class == "mhc-I":
-            idx = 0
-        elif mhc_class == "mhc-II":
-            idx = 1
-
-        if self.combined[idx] == "":
-            self.combined[idx] += "cat "
-            self.combined[idx] += neoepitopes_file
-            self.combined[idx] += " > "
-            self.combined[idx] += f"{self.options.output_dir}/{mhc_class}_neoepitopes_all.txt"
-        else:
-            self.combined[idx] += " && tail -n +2 "
-            self.combined[idx] += neoepitopes_file
-            self.combined[idx] += " >> "
-            self.combined[idx] += f"{self.options.output_dir}/{mhc_class}_neoepitopes_all.txt"
+        self.combined[mhc_class].append(neoepitopes_file)
 
 def main():
     options = parse_arguments()

--- a/workflow/scripts/quantification/featurecounts_wrapper.py
+++ b/workflow/scripts/quantification/featurecounts_wrapper.py
@@ -25,8 +25,9 @@ def main():
 def get_mode(inputbam):
     """ This function checks if the input is in paired-end or single-end mode. """
     tmpfile = tempfile.NamedTemporaryFile(delete=False)
-    call = f"samtools view -f 1 {inputbam} -o {tmpfile.name}" 
-    subprocess.run(call, shell=True, check=True)
+    subprocess.run(
+        ["samtools", "view", "-f", "1", inputbam, "-o", tmpfile.name],
+        check=True)
 
     if os.stat(tmpfile.name).st_size == 0:
         return "SE"
@@ -35,14 +36,22 @@ def get_mode(inputbam):
 
 def featureCounts(mode, inputfile, outputfile, annofile, mapq, threads):
     """ This function calls featureCounts"""
-    call = "featureCounts "
+    cmd = ["featureCounts"]
     if mode == "PE":
-        call += "-p "
-    call += "-F GTF -t gene -g gene_id --fracOverlap 0.2 "
-    call += f"-Q {mapq} -T {threads} "
-    call += f"-a {annofile} -o {outputfile} {inputfile} "
+        cmd.append("-p")
+    cmd.extend([
+        "-F", "GTF",
+        "-t", "gene",
+        "-g", "gene_id",
+        "--fracOverlap", "0.2",
+        "-Q", str(mapq),
+        "-T", str(threads),
+        "-a", annofile,
+        "-o", outputfile,
+        inputfile,
+    ])
 
     # run featureCounts
-    subprocess.run(call, shell=True, check=True)
+    subprocess.run(cmd, check=True)
 
 main()


### PR DESCRIPTION
## Summary
### Fixed
- Replaced `shell=True` + string-interpolated subprocess calls with list-based `subprocess.run(..., check=True)` across 5 wrapper scripts. Eliminates breakage on paths containing spaces/special characters and lets failures fail loudly instead of cascading.
- Refactored `compile.combine_neoepitopes` to do the per-MHC-class file concatenation directly in Python (skipping the header line on second+ files) instead of building a `cat ... > out && tail -n +2 ... >> out` shell pipeline.
- `get_readgroups.scan_bamfile` now filters `@RG` lines in Python after capturing `samtools view -H`, instead of piping samtools to `grep`.
- Re-raise `CalledProcessError` in the `optitype_wrapper` and `get_readgroups` handlers so the wrapper still fails the rule after logging (per CodeRabbit review; see inline comments).
- **Found while testing this PR**: fixed dead VQSR download URLs in `germline.smk` (the Broad's hg38 bucket moved from `genomics-public-data/resources/broad/hg38/v0/` → `gcp-public-data--broad-references/hg38/v0/`; the old URLs caused `curl` to silently save a 298-byte XML 403 page as the VCF) and added `--fail` to every `curl` invocation across the 5 rule files that download anything (23 total). This contributes to #63 — the `--fail` half is now complete in this PR; checksum verification remains.

### Files changed
- `workflow/scripts/genotyping/optitype_wrapper.py` — also fixes a latent bug: original `Popen("samtools index ...")` did not wait, so a missing/incomplete `.bai` could be used downstream.
- `workflow/scripts/genotyping/finalize_mhcII_input.py`
- `workflow/scripts/get_readgroups.py`
- `workflow/scripts/prioritization/compile.py`
- `workflow/scripts/quantification/featurecounts_wrapper.py`
- `workflow/rules/germline.smk` (URL fix + `--fail`)
- `workflow/rules/ref.smk` (`--fail`)
- `workflow/rules/hlatyping_prep.smk` (`--fail`)
- `workflow/rules/annotation.smk` (`--fail`)
- `workflow/rules/prioritization.smk` (`--fail`)

### Out of scope
- `workflow/scripts/transindel/transIndel_build_{DNA,RNA}.py` (listed in #62) live in the `cauyrd/transIndel` submodule — fixes need to go upstream there, not in this repo.
- `workflow/scripts/scanexitron/` — same situation (upstream submodule).
- Checksum verification of downloaded files (the other half of #63) — left for a follow-up.

Closes #62
Contributes to #63

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] `python3 -m py_compile` succeeds on each modified Python file
- [x] No `shell=True` remains in the 5 audited (non-submodule) scripts
- [x] No `curl` invocation across `workflow/rules/` runs without `--fail` (23/23 covered)
- [x] All 4 broken VQSR URLs return HTTP 200 from the new `gcp-public-data--broad-references` bucket
- [x] Snakemake dry-run on `.tests/` config still parses and resolves rules
- [x] Integration test (`.tests/integration/indel-test/config_SE.yml`) reaches `recalibrate_variants_first_round` successfully (the rule that failed pre-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)