### PR TITLE
Harden _run_prediction with timeout, stderr capture, check=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Harden `_run_prediction` subprocess call**: Added `timeout=3600s` (per-batch wall-clock cap), `stderr=subprocess.PIPE`, and `check=True` to the netMHCpan/netMHCIIpan invocation in `prediction.py`. Wraps the call in `try/except subprocess.TimeoutExpired / subprocess.CalledProcessError`, logs a warning, and returns an empty dict so a single hung or failing batch doesn't stall the whole prioritization run. ([#59](https://github.com/ylab-hi/ScanNeo2/issues/59), [#75](https://github.com/ylab-hi/ScanNeo2/pull/75))
+
 ### Fixed
 
 - **Replace shell=True subprocess calls with list-based arguments**: Refactored 5 wrapper scripts (`optitype_wrapper`, `finalize_mhcII_input`, `get_readgroups`, `compile`, `featurecounts_wrapper`) to use list-based `subprocess.run(..., check=True)` instead of shell=True string commands. Eliminates path-with-spaces breakage, surfaces tool stderr, and lets failures fail loudly. `compile.combine_neoepitopes` rewritten to concatenate files in Python; `get_readgroups.scan_bamfile` filters `@RG` headers in Python instead of piping samtools to grep. ([#62](https://github.com/ylab-hi/ScanNeo2/issues/62), [#74](https://github.com/ylab-hi/ScanNeo2/pull/74))

--- a/workflow/scripts/prioritization/prediction.py
+++ b/workflow/scripts/prioritization/prediction.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import utility as ut
 
 BATCH_SIZE = 500
+PREDICTION_TIMEOUT_SEC = 3600  # per-batch wall-clock cap for netMHCpan / netMHCIIpan
 
 class BindingAffinities:
     def __init__(self, threads):
@@ -338,12 +339,28 @@ class BindingAffinities:
     @staticmethod
     def _run_prediction(call, fa_file, group, mhc_class):
         """Run a single prediction subprocess and parse its output into a
-        binding_affinities dict keyed by (seqnum -> epitope_seq -> tuple)."""
+        binding_affinities dict keyed by (seqnum -> epitope_seq -> tuple).
+
+        A hung or failing batch is skipped (returns an empty dict) so one
+        bad batch does not stall the whole run."""
         binding_affinities = {}
 
-        result = subprocess.run(call,
-                                stdout=subprocess.PIPE,
-                                universal_newlines=True)
+        try:
+            result = subprocess.run(call,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE,
+                                    universal_newlines=True,
+                                    timeout=PREDICTION_TIMEOUT_SEC,
+                                    check=True)
+        except subprocess.TimeoutExpired:
+            print(f"    WARNING: prediction timed out after "
+                  f"{PREDICTION_TIMEOUT_SEC}s for {fa_file}", flush=True)
+            return binding_affinities
+        except subprocess.CalledProcessError as e:
+            print(f"    WARNING: prediction failed for {fa_file}: "
+                  f"{e.stderr}", flush=True)
+            return binding_affinities
+
         predictions = result.stdout.rstrip().split('\n')[1:]
 
         for line in predictions:


### PR DESCRIPTION
## Summary
### Changed
- `BindingAffinities._run_prediction` now passes `timeout=PREDICTION_TIMEOUT_SEC` (1h per batch), `stderr=subprocess.PIPE`, and `check=True` to `subprocess.run`.
- Wraps the call in `try/except subprocess.TimeoutExpired / subprocess.CalledProcessError`, logs a warning, and returns an empty `binding_affinities` dict so a single bad batch doesn't stall the whole prioritization run.
- Added `PREDICTION_TIMEOUT_SEC = 3600` as a module-level constant alongside `BATCH_SIZE`, so the timeout is easy to tune in one place.

### Why
- Per @riasc's follow-up to #58: batching already prevents the original hang on giant FASTA inputs, but a single stuck batch (NFS stall, wedged tool process, etc.) could still hang indefinitely because `subprocess.run` had no timeout.
- Captured stderr surfaces netMHCpan / netMHCIIpan error messages in the Snakemake log instead of swallowing them.

Closes #59

## QC
- [ ] I, as a human being, have checked each line of code in this pull request
- [x] `python3 -m py_compile workflow/scripts/prioritization/prediction.py` succeeds
- [ ] Existing prioritization rule on the `.tests/` config still completes end-to-end (no behavior change on the happy path)
- [ ] Manually injected failure case (e.g. point the prediction script at a non-executable) produces a `WARNING: prediction failed` line and does not raise

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness of batch prediction processing with timeout protection and improved error handling. Failed or timed-out batches are now gracefully skipped instead of blocking the entire prioritization workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ylab-hi/ScanNeo2/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->