### PR TITLE
Release v0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9] - 2026-05-17
+
 ### Added
 
 - **Pytest scaffolding and unit tests for `combine_all_alleles.py`**: First testing-infrastructure PR. Adds `pytest.ini`, `.github/workflows/test.yml` (runs `pytest .tests/unit/` on Python 3.12), `.gitignore`, and 6 unit tests covering the script's happy path, allele-field truncation, off-refset rejection, empty-input diagnosis, malformed-line rejection, and mixed-source breakdown. Locks in the diagnostic behavior added in PR #83. Hand-rolled rather than auto-generated because naive `snakemake --generate-unit-tests` produces 6+ GB fixtures (vendored IEDB tools declared as rule inputs). ([#85](https://github.com/ylab-hi/ScanNeo2/pull/85))


### PR DESCRIPTION
## Summary

Promotes the accumulated `[Unreleased]` entries to a tagged version. Patch bump per SemVer — all changes are backwards-compatible.

**10 entries since v0.3.8** (2026-03-26):

### Added (1)
- Pytest scaffolding + first unit tests for `combine_all_alleles.py` (#85)

### Changed (4)
- Harden `_run_prediction` subprocess call (timeout, stderr, check) (#75)
- Switch `optitype_wrapper.py` to multiple positional BAM args (#78)
- Add global `wildcard_constraints` to Snakefile (#81)
- Clean up dead code, unused imports, temp-file leak (#84)

### Fixed (5)
- Improve `combine_all_alleles.py` diagnostics on zero-alleles failure (#83)
- Apply `:q` to all BAM placeholders in `hlatyping_mhcI.smk` (#82)
- Remove spurious `.bai` input from `split_reads_mhcI_SE` (folded into #78)
- Replace shell=True subprocess calls with list-based arguments (#74)
- Fix dead VQSR download URLs and add `--fail` to all curl rules (#74)

## User-visible wins

1. **VQSR URL fix** unblocks anyone running germline indel detection on hg38 (the Broad's `genomics-public-data` bucket moved to `gcp-public-data--broad-references`)
2. **Paths-with-spaces fixes** across the shell=True refactor, optitype wrapper, and `:q` quoting make the workflow robust on cluster paths containing spaces
3. **Better failure messages** in `combine_all_alleles.py` cut diagnostic time on low-HLA-coverage runs by naming which source TSV was empty + where to look upstream

## Release procedure (after merge)

1. Tag the merge commit: `git tag v0.3.9 && git push origin v0.3.9`
2. Create the GitHub release: `gh release create v0.3.9 --title "v0.3.9" --notes-file <CHANGELOG-excerpt>` (matches the v0.3.8 release format)

## QC
- [ ] I, as a human being, have checked each line of code in this pull request
- [x] CHANGELOG.md `[Unreleased]` section accurately reflects all merged PRs since v0.3.8 (verified against `git log v0.3.8..main --oneline`)
- [x] Version bump matches the changes (patch bump — no breaking API changes)
- [x] Date in version header matches today (2026-05-17)
- [x] Fresh empty `## [Unreleased]` block kept at the top for future entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)