### PR TITLE
Release v0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.10] - 2026-05-20
+
 ### Fixed
 
 - **Drop `tmp/` as rule input to stop spurious reruns**: Three rules (`rnaseq_postproc_markdup`, `dnaseq_postproc`, `get_reads_hlatyping_BAM`) declared `tmp="tmp/"` as input, but `samtools sort -T tmp/` and intermediate BAMs in those same rules wrote into the directory — bumping its mtime so Snakemake's mtime trigger re-fired the rules on every invocation. Each rule now `mkdir -p tmp/` itself, removing the input dependency entirely; the now-orphan `create_tmp_folder` rule and `workflow/rules/prelim.smk` are deleted, and the `include:` line in `workflow/Snakefile` is removed. Each `samtools sort -T` now uses a wildcard-tagged prefix (`tmp/sort_{sample}_{group}_`, `tmp/sort_{sample}_{group}_{nartype}_`) so concurrent jobs' shards are visibly attributable. ([#31](https://github.com/ylab-hi/ScanNeo2/issues/31), [#91](https://github.com/ylab-hi/ScanNeo2/pull/91))


### PR DESCRIPTION
Promotes the accumulated `## [Unreleased]` CHANGELOG entries to a tagged **v0.3.10** release.

## Included since v0.3.9

### Fixed
- **Drop `tmp/` as rule input to stop spurious reruns** ([#31](https://github.com/ylab-hi/ScanNeo2/issues/31), [#91](https://github.com/ylab-hi/ScanNeo2/pull/91))
- **Wrap shell pipelines so stderr from upstream commands lands in the rule log** ([#88](https://github.com/ylab-hi/ScanNeo2/issues/88), [#90](https://github.com/ylab-hi/ScanNeo2/pull/90))
- **Fix two NaN crashes in `prioritization/filtering.py`** ([#87](https://github.com/ylab-hi/ScanNeo2/pull/87))

### Changed
- **Mark large intermediates as `temp()`** ([#67](https://github.com/ylab-hi/ScanNeo2/issues/67), [#87](https://github.com/ylab-hi/ScanNeo2/pull/87))
- **Harden Python file handling and subprocess calls** ([#68](https://github.com/ylab-hi/ScanNeo2/issues/68), [#92](https://github.com/ylab-hi/ScanNeo2/pull/92))

All changes are backwards-compatible.

## QC
- [ ] I, as a human being, have reviewed the release diff
- [x] CHANGELOG `## [Unreleased]` promoted to `## [0.3.10] - 2026-05-20` with a fresh empty `## [Unreleased]` above
- [x] Diff is CHANGELOG-only (version is not duplicated in code/config)

After merge: tag `v0.3.10` on the merge commit and create the GitHub release.