### PR TITLE
Pin loose conda dependencies across env files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Pin loose conda dependencies**: Pinned the remaining unpinned packages across 6 `workflow/envs/*.yml` files (`curl`, `bowtie2`, `pip`, `python`, `perl`, `perl-env`, `bwa`, `samtools`, `pysam`) to versions verified by dry-run solving each env. `realign.yml` also gained the `conda-forge` channel — without it the solver starved modern samtools of its dependencies and fell back to samtools 1.3.1 — and `manipulate_vcf.yml` had its channels reordered to `conda-forge, bioconda` (dropping `defaults`, which had resolved `pysam` to 0.9.1 and conflicted on `libdeflate`). ([#64](https://github.com/ylab-hi/ScanNeo2/issues/64), [#101](https://github.com/ylab-hi/ScanNeo2/pull/101))
+
 ## [0.3.10] - 2026-05-20
 
 ### Fixed

--- a/workflow/envs/basic.yml
+++ b/workflow/envs/basic.yml
@@ -10,4 +10,4 @@ dependencies:
   - biopython=1.78
   - gffutils=0.12
   - pysam=0.22.0
-  - curl
+  - curl=8.8.0

--- a/workflow/envs/hlahd.yml
+++ b/workflow/envs/hlahd.yml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - bowtie2
+  - bowtie2=2.5.5

--- a/workflow/envs/manipulate_vcf.yml
+++ b/workflow/envs/manipulate_vcf.yml
@@ -1,11 +1,10 @@
 channels:
-  - bioconda
   - conda-forge
-  - defaults
+  - bioconda
 dependencies:
-  - python
+  - python=3.8
   - pyfaidx=0.7.0
-  - pysam
+  - pysam=0.22.0
   - configargparse=1.7
   - pip=24.3.1
   - pip:

--- a/workflow/envs/prioritization.yml
+++ b/workflow/envs/prioritization.yml
@@ -3,7 +3,7 @@ channels:
  - conda-forge
  - anaconda
 dependencies:
- - python>=3.7
+ - python=3.7
  - vcfpy=0.13.6
  - pyfaidx=0.7.0
  - configargparse=1.7
@@ -11,8 +11,8 @@ dependencies:
  - blast=2.15.0
  - zstd=1.5.5
  - pip=24.0
- - perl
- - perl-env
+ - perl=5.26.2
+ - perl-env=1.04
  - pip:
    - gffutils==0.12
    - blosum==2.0.2

--- a/workflow/envs/realign.yml
+++ b/workflow/envs/realign.yml
@@ -1,5 +1,6 @@
 channels:
+  - conda-forge
   - bioconda
 dependencies:
-  - bwa
-  - samtools
+  - bwa=0.7.17
+  - samtools=1.16.1

--- a/workflow/envs/spladder.yml
+++ b/workflow/envs/spladder.yml
@@ -3,6 +3,6 @@ channels:
  - bioconda
 dependencies:
  - python=3.8
- - pip
+ - pip=24.2
  - pip:
    - spladder==3.0.4


### PR DESCRIPTION
## Summary
### Changed
- Pinned the remaining unpinned packages across 6 `workflow/envs/*.yml` files. Each version was chosen by dry-run solving the env and taking the resolved version, then re-solving to confirm a clean resolution.

**Clean pins — no behaviour change (freezes what already resolves):**
- `basic.yml`: `curl` → `curl=8.8.0`
- `hlahd.yml`: `bowtie2` → `bowtie2=2.5.5`
- `spladder.yml`: `pip` → `pip=24.2`
- `prioritization.yml`: `python>=3.7` → `python=3.7`; `perl` → `perl=5.26.2`; `perl-env` → `perl-env=1.04`

**Channel fixes — two envs resolved to accidental ancient versions:**
- `realign.yml`: added the `conda-forge` channel (only `bioconda` was listed, which starved modern samtools of its dependencies and resolved `samtools` to **1.3.1**, from 2016). Pinned `bwa=0.7.17` + `samtools=1.16.1` to match `basic.yml`. The `realign` / `bwa_align_dnaseq` rules use only `samtools collate`/`fastq`/`sort` — present in both versions — so the risk is low.
- `manipulate_vcf.yml`: reordered channels to `conda-forge, bioconda` and dropped the `defaults` channel (the `bioconda`-first + `defaults` ordering resolved `pysam` to **0.9.1**, from 2016, and conflicted on `libdeflate` when 0.22.0 was tried). Pinned `python=3.8` + `pysam=0.22.0`. The 7 rules using this env are VCF-conversion rules (vcfpy/pyfaidx-based); `pysam` is a listed-but-unused dependency, so the risk is low.

Closes #64

## QC
- [ ] I, as a human being, have checked each line of code in this pull request
- [x] All 6 modified envs verified to build cleanly via a full `mamba env create` (real build, not dry-run), including the `pip:` installs (`vcfpy`, `gffutils`, `blosum`, `spladder`)
- [x] The two channel-fix envs (`realign.yml`, `manipulate_vcf.yml`) build cleanly under the new channel configuration; all test envs removed afterward