### PR TITLE
Improve documentation: README, config comments, script docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Pin loose conda dependencies**: Pinned the remaining unpinned packages across 6 `workflow/envs/*.yml` files (`curl`, `bowtie2`, `pip`, `python`, `perl`, `perl-env`, `bwa`, `samtools`, `pysam`) to versions verified by dry-run solving each env. `realign.yml` also gained the `conda-forge` channel — without it the solver starved modern samtools of its dependencies and fell back to samtools 1.3.1 — and `manipulate_vcf.yml` had its channels reordered to `conda-forge, bioconda` (dropping `defaults`, which had resolved `pysam` to 0.9.1 and conflicted on `libdeflate`). ([#64](https://github.com/ylab-hi/ScanNeo2/issues/64), [#101](https://github.com/ylab-hi/ScanNeo2/pull/101))
+- **Improve documentation**: Fixed the self-contradictory Snakemake-version note and a `config.yml`→`config.yaml` typo in the README, and clarified that HLA-HD's `hlahd.sh` must be on `PATH`. Added inline comments to the previously-undocumented `config/config.yaml` options (`reference`, `data`, `preproc`, the STAR chimeric-alignment parameters, `quantification`, the HLA-HD reference-data paths, `prioritization` lengths). Added module-level docstrings to all 8 `workflow/scripts/prioritization/` modules. ([#71](https://github.com/ylab-hi/ScanNeo2/issues/71), [#102](https://github.com/ylab-hi/ScanNeo2/pull/102))
 
 ## [0.3.10] - 2026-05-20
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To get started with ScanNeo2, follow the steps below:
     mamba activate scanneo2
     ```
 
-    Note: ScanNeo2 requires Snakemake >= 8.x.x is not compatible with Snakemake <= 8.x.x. 
+    Note: ScanNeo2 requires Snakemake >= 8.0 and is not compatible with earlier versions.
 
 2. Deploy ScanNeo2:
 
@@ -54,7 +54,8 @@ cd ScanNeo2
 
     ScanNeo2 employs HLA-HD for HLA Class II genotyping which is required when ScanNeo2 has been configured to predict class II neoantigens. 
     Due to license reasons it has to be installed manually (download request). Please follow the instructions on the official 
-    [website](https://w3.genome.med.kyoto-u.ac.jp/HLA-HD/). HLA-HD needs to be installed system-wide. In particular, ScanNeo2 calls `hlahd.sh`. 
+    [website](https://w3.genome.med.kyoto-u.ac.jp/HLA-HD/). ScanNeo2 invokes HLA-HD's `hlahd.sh` script directly, so the 
+    HLA-HD `bin/` directory must be on your `PATH` (i.e. running `hlahd.sh` from any directory must succeed). 
     ScanNeo2 has been tested using HLA-HD v1.7.1
 
 <!--
@@ -66,7 +67,7 @@ cd ScanNeo2
     ```
 -->
 
-3. Configure ScanNeo2 by editing the `config/config.yml` file. Make sure to adjust parameters to suit your needs and data. Note that the paths in the config file need to be relative to the directory from which you run snakemake.
+3. Configure ScanNeo2 by editing the `config/config.yaml` file. Make sure to adjust parameters to suit your needs and data. Note that the paths in the config file need to be relative to the directory from which you run snakemake.
 
 ### Running the Workflow
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,42 +2,43 @@
 
 # General settings
 reference:
-  release: 111
-  nonchr: false
-threads: 30
-mapq: 30  # overall required mapping quality
-basequal: 20  # overall required base quality 
+  release: 111      # Ensembl release used to download the reference genome and annotation
+  nonchr: false     # whether (=true) to include non-chromosomal/scaffold contigs
+threads: 30         # maximum number of threads any single rule may use
+mapq: 30            # minimum read mapping quality (MAPQ, Phred-scaled)
+basequal: 20        # minimum base-call quality (Phred-scaled)
 
 data:
-  name:  samplename
-  dnaseq: 
-    dna_tumor: <path/to/reads>
-  rnaseq:
+  name:  samplename                    # run name; results are written to results/<name>/
+  dnaseq:                              # DNA-seq inputs; one entry per group (the key is the group name)
+    dna_tumor: <path/to/reads>         #   value: one path (single-end) or two space-separated paths (paired-end); .fastq/.fq/.bam
+  rnaseq:                              # RNA-seq inputs; same format as dnaseq
     rna_tumor: <path/to/to/reads>
-  normal: <normal/sample/identifier>
-  
+  normal: <normal/sample/identifier>   # group name of the matched normal/control sample (for somatic calling)
+
   custom:
-    variants:
-    hlatyping:
-      MHC-I:
-      MHC-II:
+    variants:                          # optional: path to a user-supplied VCF to prioritize directly
+    hlatyping:                         # optional: user-supplied HLA alleles (used when the *_mode below is 'custom')
+      MHC-I:                           #   path to a file listing MHC class I alleles
+      MHC-II:                          #   path to a file listing MHC class II alleles
 
 ### pre-processing (only applied on fastq reads)
 preproc: 
   activate: true  # whether (=true) or not (=false) to include pre-processing
-  minlen: 10
+  minlen: 10      # discard reads shorter than this (bp) after trimming
   slidingwindow:
     activate: true
-    wsize: 3
-    wqual: 20
+    wsize: 3      # sliding-window size (bp) for quality trimming
+    wqual: 20     # mean base quality required within the window (Phred-scaled)
 
-### alingment
+### alignment
+# STAR chimeric-alignment parameters (used for RNA-seq gene-fusion detection)
 align:
-  chimSegmentMin: 20
-  chimScoreMin: 10
-  chimJunctionOverhangMin: 10
-  chimScoreDropMax: 30
-  chimScoreSeparation: 10
+  chimSegmentMin: 20            # minimum length of each chimeric segment (0 disables chimeric detection)
+  chimScoreMin: 10              # minimum total score of a chimeric alignment
+  chimJunctionOverhangMin: 10   # minimum overhang length for a chimeric junction
+  chimScoreDropMax: 30          # maximum allowed drop of chimeric score below read length
+  chimScoreSeparation: 10       # minimum score separation between the best and next-best chimeric alignment
 
 ### variant calling
 # alternative splicing
@@ -82,22 +83,21 @@ indel:
   sliprate: 0.1  # frequency of slippage when it is supsected
 
 quantification:
-  mode: BOTH # RNA, RNA or BOTH
+  mode: BOTH  # quantify expression from DNA, RNA, or BOTH
 
 hlatyping:
   class: BOTH # I, II or BOTH
-  # specific path for class II hlatyping (only required when class: II, or BOTH)
   MHC-I_mode: DNA, RNA # DNA, RNA, or custom (if empty alleles have to be specified in custom)
   MHC-II_mode: DNA, RNA # DNA, RNA, or custom (if empty alleles have to be specified in custom)
-  
-  # specific path for class II hlatyping (only required when class: II, or BOTH)
-  freqdata: ./hlahd_files/freq_data/ 
-  split: ./hlahd_files/HLA_gene.split.txt
-  dict: ./hlahd_files/dictionary/
+
+  # HLA-HD reference data (only required when class: II or BOTH)
+  freqdata: ./hlahd_files/freq_data/        # HLA-HD frequency-data directory
+  split: ./hlahd_files/HLA_gene.split.txt   # HLA-HD gene-split file
+  dict: ./hlahd_files/dictionary/           # HLA-HD dictionary directory
 
 prioritization:
   class: I # I, II or BOTH
-  lengths:
+  lengths:                  # comma-separated epitope lengths (aa) to predict per MHC class
     MHC-I: 8,9,10,11
     MHC-II: 13,14,15
 

--- a/workflow/scripts/prioritization/compile.py
+++ b/workflow/scripts/prioritization/compile.py
@@ -1,3 +1,10 @@
+"""Entry point for the neoantigen prioritization stage, invoked by the `prioritization` Snakemake rule.
+
+For each variant source (SNVs, short/long indels, exitrons, alternative splicing, fusions, custom) it
+annotates variant effects, predicts MHC binding affinities, applies similarity/immunogenicity scoring,
+and combines the per-source neoepitope tables into the final output.
+"""
+
 import os
 import sys
 import configargparse

--- a/workflow/scripts/prioritization/effects.py
+++ b/workflow/scripts/prioritization/effects.py
@@ -1,3 +1,10 @@
+"""Derive the protein-level effect of each variant.
+
+Reconstructs the wildtype/mutant peptide subsequence around each variant, determines NMD status and
+PTC location for frameshift events, attaches expression (TPM), and writes the per-variant-type
+`*_variant_effects.tsv` consumed by the binding-affinity prediction step.
+"""
+
 # classes
 import utility as ut
 import reference

--- a/workflow/scripts/prioritization/filtering.py
+++ b/workflow/scripts/prioritization/filtering.py
@@ -1,3 +1,10 @@
+"""Post-prediction scoring of neoepitopes.
+
+`Immunogenicity` adds IEDB immunogenicity scores; `SequenceSimilarity` adds self-similarity
+(wildtype vs mutant), pathogen similarity, and proteome similarity (both via blastp). Each appends
+columns to the per-variant-type neoepitope tables.
+"""
+
 import os
 import sys
 import pandas as pd

--- a/workflow/scripts/prioritization/fusions.py
+++ b/workflow/scripts/prioritization/fusions.py
@@ -1,3 +1,9 @@
+"""Process gene-fusion events.
+
+Reads arriba fusion calls, reconstructs the fusion transcript and its wildtype/mutant peptide
+sequences, and registers each as a variant effect for downstream neoepitope prediction.
+"""
+
 # classes
 import utility as ut
 import effects

--- a/workflow/scripts/prioritization/prediction.py
+++ b/workflow/scripts/prioritization/prediction.py
@@ -1,3 +1,10 @@
+"""MHC binding-affinity prediction.
+
+Extracts candidate epitope subsequences from the variant-effects table, runs netMHCpan / netMHCIIpan
+(IEDB tools) in batches across the sample's HLA alleles and the configured epitope lengths, and writes
+the per-variant-type neoepitope tables with binding affinity, rank, and agretopicity.
+"""
+
 import tempfile
 import os
 import contextlib

--- a/workflow/scripts/prioritization/reference.py
+++ b/workflow/scripts/prioritization/reference.py
@@ -1,3 +1,9 @@
+"""Load reference data used throughout prioritization.
+
+`Proteome` indexes the reference peptide FASTA by transcript ID, `Annotation` parses the GTF into
+transcriptome and exome coordinate maps, and `Counts` loads the per-gene expression count table.
+"""
+
 import pyfaidx
 import re
 

--- a/workflow/scripts/prioritization/utility.py
+++ b/workflow/scripts/prioritization/utility.py
@@ -1,3 +1,5 @@
+"""Small shared helpers for the prioritization scripts (output formatting, sequence inspection)."""
+
 def format_output(field):
     if field == None:
         return '.'

--- a/workflow/scripts/prioritization/variants.py
+++ b/workflow/scripts/prioritization/variants.py
@@ -1,3 +1,10 @@
+"""Process VEP-annotated variants (SNVs and indels).
+
+Reads a VCF, resolves each VEP consequence (missense, frameshift, inframe insertion/deletion),
+reconstructs the wildtype/mutant peptide sequence, and registers each as a variant effect for
+downstream neoepitope prediction.
+"""
+
 from pathlib import Path
 import re
 import vcfpy


### PR DESCRIPTION
## Summary
### Changed
- **README** — three fixes flagged by the audit: corrected the self-contradictory Snakemake-version sentence (*"requires Snakemake >= 8.x.x is not compatible with Snakemake <= 8.x.x"*), clarified that HLA-HD's `hlahd.sh` must be on `PATH`, and fixed a `config/config.yml` → `config/config.yaml` typo.
- **config/config.yaml** — added inline comments for the previously undocumented options: `reference` (`release`, `nonchr`), `data` (input layout, groups, custom inputs), `preproc` (`minlen`, sliding-window params), the STAR chimeric-alignment parameters under `align`, `quantification.mode`, the HLA-HD reference-data paths, and `prioritization.lengths`. Also fixed the `### alingment` and `# RNA, RNA or BOTH` typos.
- **`workflow/scripts/prioritization/`** — added a module-level docstring to all 8 modules (`compile`, `effects`, `filtering`, `fusions`, `prediction`, `reference`, `utility`, `variants`), each describing the module's role in the prioritization pipeline.

Closes #71

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] `config/config.yaml` still parses as valid YAML
- [x] All 8 prioritization modules still `py_compile` cleanly with the new docstrings
- [x] Documentation-only — no behaviour change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified Snakemake >= 8.0 version requirement in installation instructions
  * Enhanced HLA-HD setup guidance for PATH configuration
  * Improved configuration file with clearer examples and expanded inline comments
  * Added descriptive documentation to workflow scripts for better code maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ylab-hi/ScanNeo2/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->