### PR TITLE
Release v0.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.11] - 2026-05-21
+
 ### Changed
 
 - **Pin loose conda dependencies**: Pinned the remaining unpinned packages across 6 `workflow/envs/*.yml` files (`curl`, `bowtie2`, `pip`, `python`, `perl`, `perl-env`, `bwa`, `samtools`, `pysam`) to versions verified by dry-run solving each env. `realign.yml` also gained the `conda-forge` channel — without it the solver starved modern samtools of its dependencies and fell back to samtools 1.3.1 — and `manipulate_vcf.yml` had its channels reordered to `conda-forge, bioconda` (dropping `defaults`, which had resolved `pysam` to 0.9.1 and conflicted on `libdeflate`). ([#64](https://github.com/ylab-hi/ScanNeo2/issues/64), [#101](https://github.com/ylab-hi/ScanNeo2/pull/101))


### PR DESCRIPTION
## Summary

Rolls `[Unreleased]` into `## [0.3.11] - 2026-05-21`. CHANGELOG-only — no code changes. Tag `v0.3.11` after merge.

### Included since v0.3.10

**Changed**
- Pin loose conda dependencies across 6 `workflow/envs/*.yml` ([#101](https://github.com/ylab-hi/ScanNeo2/pull/101))
- Improve documentation — README, `config.yaml` comments, prioritization script docstrings ([#102](https://github.com/ylab-hi/ScanNeo2/pull/102))
- Standardize STAR / samtools / fastqc wrapper versions ([#103](https://github.com/ylab-hi/ScanNeo2/pull/103))
- Structured startup run summary and clearer config errors ([#106](https://github.com/ylab-hi/ScanNeo2/pull/106))
- Add JSON Schema validation for the config file ([#107](https://github.com/ylab-hi/ScanNeo2/pull/107))

**Fixed**
- Strip the wildtype-padding `$` sentinel before it reaches epitope output ([#107](https://github.com/ylab-hi/ScanNeo2/pull/107))

## QC
- [ ] I, as a human being, have checked each line of code in this pull request
- [x] CHANGELOG `[0.3.11]` entries match the PRs merged since v0.3.10