### PR TITLE
Fix epitope-to-variant mis-association from batched prediction FASTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fix epitope-to-variant mis-association from batched prediction FASTA**: `predict_binding.py` numbers the sequences of each FASTA file it receives starting from 1, ignoring the `>N` header. `split_fasta_into_batches` split the prediction FASTA into 500-sequence batches, so every batch was numbered independently and `calc_binding_affinities` collapsed every global record `K, K+500, …` onto key `K`. The output-assembly loop looks variants up by their global sequence number, so variants past the first 500 had their binding affinities — and epitope sequences — attached to the wrong variant. `split_fasta_into_batches` now returns each batch's global offset and `calc_binding_affinities` translates the per-batch sequence number to a global one (`offset + per-batch number`) before keying. ([#109](https://github.com/ylab-hi/ScanNeo2/issues/109), [#111](https://github.com/ylab-hi/ScanNeo2/pull/111))
+
 ## [0.3.11] - 2026-05-21
 
 ### Changed

--- a/workflow/scripts/prioritization/prediction.py
+++ b/workflow/scripts/prioritization/prediction.py
@@ -300,13 +300,17 @@ class BindingAffinities:
     
     @staticmethod
     def split_fasta_into_batches(fa_file, batch_dir, batch_size=BATCH_SIZE):
-        """Split a FASTA file into smaller batch files of at most batch_size
-        sequences each.  Returns a list of batch file paths.  Original
-        sequence IDs (the >N header lines) are preserved so results can be
-        merged back without remapping."""
+        """Split a FASTA file into batch files of at most batch_size sequences.
+
+        Returns a list of (batch_file, offset) tuples. The prediction tool
+        numbers the sequences in each file it receives starting from 1, so the
+        offset -- the count of sequences in all preceding batches -- is needed
+        to recover a global sequence number: global = offset + per-batch number.
+        """
         batches = []
         current_lines = []
-        seq_count = 0
+        seq_count = 0       # sequences in the batch currently being built
+        total_count = 0     # sequences already flushed to preceding batches
 
         with open(fa_file, 'r') as fh:
             for line in fh:
@@ -317,7 +321,8 @@ class BindingAffinities:
                             batch_dir, f'batch_{len(batches)}.fa')
                         with open(batch_file, 'w') as bf:
                             bf.writelines(current_lines)
-                        batches.append(batch_file)
+                        batches.append((batch_file, total_count))
+                        total_count += seq_count
                         current_lines = []
                         seq_count = 0
                     seq_count += 1
@@ -329,7 +334,7 @@ class BindingAffinities:
                 batch_dir, f'batch_{len(batches)}.fa')
             with open(batch_file, 'w') as bf:
                 bf.writelines(current_lines)
-            batches.append(batch_file)
+            batches.append((batch_file, total_count))
 
         return batches
 
@@ -414,7 +419,7 @@ class BindingAffinities:
                 fa_file, batch_dir)
             num_batches = len(batches)
 
-            for batch_idx, batch_file in enumerate(batches):
+            for batch_idx, (batch_file, offset) in enumerate(batches):
                 if num_batches > 1:
                     print(f'    batch {batch_idx + 1}/{num_batches} - '
                           f'allele:{allele} epilen:{epilen} group:{group}',
@@ -425,14 +430,17 @@ class BindingAffinities:
                 batch_results = BindingAffinities._run_prediction(
                     call, batch_file, group, mhc_class)
 
-                # merge batch results
+                # merge batch results -- the prediction tool numbers each batch
+                # file from 1, so translate the per-batch sequence number to a
+                # global one before keying, otherwise batches collide
                 for seqnum in batch_results:
-                    if seqnum not in binding_affinities:
-                        binding_affinities[seqnum] = batch_results[seqnum]
+                    global_seqnum = offset + seqnum
+                    if global_seqnum not in binding_affinities:
+                        binding_affinities[global_seqnum] = batch_results[seqnum]
                     else:
                         for seq in batch_results[seqnum]:
-                            if seq not in binding_affinities[seqnum]:
-                                binding_affinities[seqnum][seq] = batch_results[seqnum][seq]
+                            if seq not in binding_affinities[global_seqnum]:
+                                binding_affinities[global_seqnum][seq] = batch_results[seqnum][seq]
 
         return binding_affinities
     

--- a/workflow/scripts/prioritization/prediction.py
+++ b/workflow/scripts/prioritization/prediction.py
@@ -430,17 +430,11 @@ class BindingAffinities:
                 batch_results = BindingAffinities._run_prediction(
                     call, batch_file, group, mhc_class)
 
-                # merge batch results -- the prediction tool numbers each batch
-                # file from 1, so translate the per-batch sequence number to a
-                # global one before keying, otherwise batches collide
+                # the prediction tool numbers each batch file from 1; translate
+                # the per-batch sequence number to a global one. Global seqnums
+                # are unique across batches, so a plain assignment suffices.
                 for seqnum in batch_results:
-                    global_seqnum = offset + seqnum
-                    if global_seqnum not in binding_affinities:
-                        binding_affinities[global_seqnum] = batch_results[seqnum]
-                    else:
-                        for seq in batch_results[seqnum]:
-                            if seq not in binding_affinities[global_seqnum]:
-                                binding_affinities[global_seqnum][seq] = batch_results[seqnum][seq]
+                    binding_affinities[offset + seqnum] = batch_results[seqnum]
 
         return binding_affinities
     


### PR DESCRIPTION
## Summary
### Fixed
- **Fix epitope-to-variant mis-association in `prediction.py`.** `predict_binding.py` numbers the sequences of each FASTA file it receives from 1, ignoring the `>N` header. `split_fasta_into_batches` splits the prediction FASTA into 500-sequence batches, so every batch was numbered `1..500` independently; `_run_prediction` keyed results on that per-batch number, collapsing every global record `K, K+500, …` onto key `K`. The output-assembly loop looks variants up by their *global* sequence number, so variants past the first 500 had their binding affinities — and epitope sequences — attached to the wrong variant (~96% of SNV neoepitopes mis-associated on a real run).
- `split_fasta_into_batches` now returns `(batch_file, offset)` tuples (offset = sequence count in preceding batches); `calc_binding_affinities` translates the per-batch number to a global one (`offset + per-batch number`) before keying. `_run_prediction` and `collect_binding_affinities` are unchanged.

Closes #109

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] `split_fasta_into_batches` returns correct global offsets — verified on 450/500/501/1200-record FASTAs: batches `[0]`, `[0]`, `[0,500]`, `[0,500,1000]`, and `offset + per-batch position` equals the global record id for every record
- [ ] `prioritization` re-run on `hlatest`: every `mt_epitope_seq` in `*_neoepitopes.txt` is a substring of its variant's `mt_subseq` (0 mis-associated) — needs a SLURM run