### PR TITLE
Re-enable the variant-overlap filter so prioritization emits only variant-spanning epitopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Re-enable the variant-overlap filter in prioritization output**: `prediction.py`'s output-assembly loop emitted every epitope of a variant subsequence — including ones lying entirely up-/downstream of the mutation, which are pure wildtype (`mt_epitope_seq == wt_epitope_seq`) and not neoantigens. The filter meant to drop them was commented out due to a coordinate-frame mismatch. It is re-enabled in the `mt_subseq` frame: every occurrence of the epitope in `mt_subseq` is enumerated, and the epitope is kept only if some occurrence spans `[aa_var_start, aa_var_end]` — that occurrence also feeds the `wt_epitope_seq` slice. Enumerating (rather than first-occurrence `find()`) correctly handles a k-mer that repeats within `mt_subseq`. ([#108](https://github.com/ylab-hi/ScanNeo2/issues/108), [#114](https://github.com/ylab-hi/ScanNeo2/pull/114))
+
 ## [0.3.12] - 2026-05-22
 
 ### Fixed

--- a/workflow/scripts/prioritization/prediction.py
+++ b/workflow/scripts/prioritization/prediction.py
@@ -183,28 +183,34 @@ class BindingAffinities:
                             continue
 
                         for epitope in mt.keys():
-                            # (allele, start, end, ic50, rank)
-                            # determine by mhc_i (as determined by IEDB - 0 based)
-                            start_pos_in_subseq = int(mt[epitope][1])
-                            end_pos_in_subseq = int(mt[epitope][2])
+                            # find every position of the epitope within
+                            # mt_subseq -- the same k-mer can occur more than
+                            # once, and find() alone returns only the first
+                            positions = []
+                            pos = mt_subseq.find(epitope)
+                            while pos != -1:
+                                positions.append(pos)
+                                pos = mt_subseq.find(epitope, pos + 1)
 
-                            # check if the mutation (aa_var_[start|end]) is either
-                            # part of the epitope or upstream of it - this ensures
-                            # that the sequence is mutated
-                            # if (aa_var_end < start_pos_in_subseq or
-                                # aa_var_start > end_pos_in_subseq):
-                                # continue
+                            # keep the epitope only if some occurrence spans the
+                            # variant [aa_var_start, aa_var_end] -- one lying
+                            # entirely up-/downstream is pure wildtype, not a
+                            # neoepitope. Use that occurrence for the wt epitope.
+                            startpos = next((p for p in positions
+                                             if p <= aa_var_end
+                                             and p + len(epitope) - 1 >= aa_var_start),
+                                            None)
+                            if startpos is None:
+                                continue
 
+                            # mt[epitope] = (allele, start, end, ic50, rank)
                             final["mt_epitope_seq"] = epitope
                             final["allele"] = mt[epitope][0]
                             final["mt_epitope_ic50"] = mt[epitope][3]
                             final["mt_epitope_rank"] = mt[epitope][4]
 
-                            """ search for corresponding WT by first searching for
-                            the epitope in the mt_subseq and using this information
-                            to return the WT epitope sequence"""
-                            startpos_epitope_in_subseq = mt_subseq.find(epitope)
-                            startpos = startpos_epitope_in_subseq
+                            # the wt epitope occupies the same coordinates in
+                            # wt_subseq as the mt epitope does in mt_subseq
                             final["wt_epitope_seq"] = wt_subseq[startpos:startpos+len(epitope)]
 
                             # search for binidng affinities of wildtype sequence


### PR DESCRIPTION
## Summary
### Fixed
- **Re-enable the variant-overlap filter in `prediction.py`.** The output-assembly loop emitted *every* epitope of a variant subsequence, including ones lying entirely up-/downstream of the mutation — those are pure wildtype (`mt_epitope_seq == wt_epitope_seq`), not neoantigens. The filter that should drop them was commented out because, as written, it compared `aa_var_start`/`aa_var_end` (in the `mt_subseq` frame) against the IEDB-reported positions (in the `mt_subseq_adj` frame) — mismatched coordinate frames.
- Re-enabled in the `mt_subseq` frame: enumerate every occurrence of the epitope in `mt_subseq`, keep it only if some occurrence spans `[aa_var_start, aa_var_end]`, and feed that occurrence's position to the `wt_epitope_seq` slice. Enumerating — rather than `find()`'s first occurrence — also correctly handles a k-mer that repeats within `mt_subseq`. The now-dead `start_pos_in_subseq`/`end_pos_in_subseq` are removed.

Closes #108

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] `py_compile` passes (verified under the prioritization env Python 3.7)
- [x] Filter simulated on the existing `hlatest` output: drops 30 non-variant rows (16 `somatic.snvs` + 14 `somatic.short.indels` + 0 `long.indels`), all with `wt==mt`; drops **0** rows where `wt != mt`; join keymiss 0. Two rows where a repeated k-mer spans the variant at a non-first occurrence are correctly kept (the enumerate logic).
- [ ] `prioritization` re-run on `hlatest`: 0 rows with `mt_epitope_seq == wt_epitope_seq` — postponed; to be covered by the combined v0.3.13 prioritization test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined neoepitope sequence selection to correctly identify wildtype-aligned occurrences that overlap with variant amino-acid positions. The updated logic now intelligently selects the matching epitope occurrence rather than defaulting to the first match, improving accuracy in cases with multiple potential epitope matches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ylab-hi/ScanNeo2/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
