### PR TITLE
Flatten binding-affinity prediction into a single thread pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Parallelize binding-affinity prediction in one thread pool**: `collect_binding_affinities` previously ran `len(alleles) × len(epilens)` tasks — each processing its FASTA batches sequentially — and was called once for wt then once for mt, capping concurrency at `min(threads, alleles × epilens)` (e.g. 12 for a 3-allele, 4-length run) regardless of the allocated thread count. It and `calc_binding_affinities` are replaced by a single orchestrator that enumerates every `(group, allele, epitope-length, FASTA-batch)` unit and runs them all in one `ThreadPoolExecutor`, so concurrency scales with `min(threads, total_batches)`. The per-batch computation, global-seqnum keying and cross-allele merge are unchanged — output is identical, only the scheduling differs. ([#113](https://github.com/ylab-hi/ScanNeo2/issues/113), [#118](https://github.com/ylab-hi/ScanNeo2/pull/118))
+
 ### Fixed
 
 - **Re-enable the variant-overlap filter in prioritization output**: `prediction.py`'s output-assembly loop emitted every epitope of a variant subsequence — including ones lying entirely up-/downstream of the mutation, which are pure wildtype (`mt_epitope_seq == wt_epitope_seq`) and not neoantigens. The filter meant to drop them was commented out due to a coordinate-frame mismatch. It is re-enabled in the `mt_subseq` frame: every occurrence of the epitope in `mt_subseq` is enumerated, and the epitope is kept only if some occurrence spans `[aa_var_start, aa_var_end]` — that occurrence also feeds the `wt_epitope_seq` slice. Enumerating (rather than first-occurrence `find()`) correctly handles a k-mer that repeats within `mt_subseq`. ([#108](https://github.com/ylab-hi/ScanNeo2/issues/108), [#114](https://github.com/ylab-hi/ScanNeo2/pull/114))

--- a/workflow/scripts/prioritization/prediction.py
+++ b/workflow/scripts/prioritization/prediction.py
@@ -116,19 +116,12 @@ class BindingAffinities:
                   f"({len(self.alleles)} alleles, epitope lengths: "
                   f"{','.join(map(str, epilens))})...", flush=True)
 
-            wt_affinities = self.collect_binding_affinities(self.alleles,
-                                                            wt_fname,
-                                                            epilens,
-                                                            'wt',
-                                                            mhc_class,
-                                                            self.threads)
-
-            mt_affinities = self.collect_binding_affinities(self.alleles,
-                                                            mt_fname,
-                                                            epilens,
-                                                            'mt',
-                                                            mhc_class,
-                                                            self.threads)
+            wt_affinities, mt_affinities = self.collect_binding_affinities(
+                self.alleles,
+                {'wt': wt_fname, 'mt': mt_fname},
+                epilens,
+                mhc_class,
+                self.threads)
             print("Done", flush=True)
             
             with open(os.path.join(output_dir,
@@ -255,54 +248,65 @@ class BindingAffinities:
         return epilens
     
     @staticmethod
-    def collect_binding_affinities(alleles,
-                                   fnames,
-                                   epilens,
-                                   group,
-                                   mhc_class,
-                                   threads):
-        affinities_results = {}
-        number_threads = int(threads)
+    def collect_binding_affinities(alleles, fnames, epilens, mhc_class, threads):
+        """Run binding-affinity prediction for wt and mt over every allele,
+        epitope length and FASTA batch in a single thread pool.
 
-        total_jobs = len(alleles) * len(epilens)
-        completed_jobs = 0
-        print(f"  submitting {total_jobs} jobs ({len(alleles)} alleles x "
-              f"{len(epilens)} epitope lengths) for {group} sequences",
-              flush=True)
+        fnames is {'wt': {epilen: path}, 'mt': {epilen: path}}. Returns
+        (wt_affinities, mt_affinities), each
+        {epilen: {global_seqnum: {epitope: tuple}}}.
+        """
+        affinities = {grp: {epilen: {} for epilen in epilens}
+                      for grp in ('wt', 'mt')}
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=number_threads) as executor:
-            futures = {}
-            for allele in alleles:
+        with contextlib.ExitStack() as stack:
+            # split every (group, epilen) FASTA up front and enumerate the
+            # individual (group, allele, epilen, batch) work units
+            units = []
+            for group in ('wt', 'mt'):
                 for epilen in epilens:
-                    future = executor.submit(BindingAffinities.calc_binding_affinities,
-                                             fnames[epilen],
-                                             allele,
-                                             epilen,
-                                             group,
-                                             mhc_class)
-                    futures[future] = (epilen, allele)
+                    fa_file = fnames[group][epilen]
+                    if os.stat(fa_file).st_size == 0:
+                        continue
+                    batch_dir = stack.enter_context(tempfile.TemporaryDirectory())
+                    batches = BindingAffinities.split_fasta_into_batches(
+                        fa_file, batch_dir)
+                    for allele in alleles:
+                        for batch_file, offset in batches:
+                            units.append(
+                                (group, allele, epilen, batch_file, offset))
 
-            for future in concurrent.futures.as_completed(futures):
-                epilen, allele = futures[future]
-                completed_jobs += 1
-                print(f"  [{completed_jobs}/{total_jobs}] completed "
-                      f"allele:{allele} epilen:{epilen} group:{group}",
-                      flush=True)
-                binding_affinities = future.result()
+            print(f"  submitting {len(units)} prediction jobs "
+                  f"({len(alleles)} alleles x {len(epilens)} epitope lengths "
+                  f"x wt/mt x FASTA batches)", flush=True)
 
-                # check epilen already present
-                if epilen not in affinities_results.keys():
-                    affinities_results[epilen] = {}
+            # one pool over all units -- the prediction tool numbers each batch
+            # file from 1, so offset translates that to a global seqnum
+            completed = 0
+            with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=int(threads)) as executor:
+                futures = {}
+                for group, allele, epilen, batch_file, offset in units:
+                    call = BindingAffinities._build_call(
+                        batch_file, allele, epilen, mhc_class)
+                    future = executor.submit(BindingAffinities._run_prediction,
+                                             call, batch_file, group, mhc_class)
+                    futures[future] = (group, epilen, offset)
 
-                for seqnum in binding_affinities.keys():
-                    if seqnum not in affinities_results[epilen].keys():
-                        affinities_results[epilen][seqnum] = binding_affinities[seqnum]
-                    else:
-                        for seq in binding_affinities[seqnum].keys():
-                            if seq not in affinities_results[epilen][seqnum].keys():
-                                affinities_results[epilen][seqnum][seq] = binding_affinities[seqnum][seq]
+                for future in concurrent.futures.as_completed(futures):
+                    group, epilen, offset = futures[future]
+                    completed += 1
+                    print(f"  [{completed}/{len(units)}] completed", flush=True)
+                    dest = affinities[group][epilen]
+                    for seqnum, epitopes in future.result().items():
+                        global_seqnum = offset + seqnum
+                        if global_seqnum not in dest:
+                            dest[global_seqnum] = epitopes
+                        else:
+                            for seq, val in epitopes.items():
+                                dest[global_seqnum].setdefault(seq, val)
 
-        return affinities_results
+        return affinities['wt'], affinities['mt']
     
     @staticmethod
     def split_fasta_into_batches(fa_file, batch_dir, batch_size=BATCH_SIZE):
@@ -412,37 +416,6 @@ class BindingAffinities:
             return ["python",
                     "workflow/scripts/mhc_ii/mhc_II_binding.py",
                     "netmhciipan_ba", allele, batch_file, str(epilen)]
-
-    @staticmethod
-    def calc_binding_affinities(fa_file, allele, epilen, group, mhc_class):
-        binding_affinities = {}
-
-        if os.stat(fa_file).st_size == 0:
-            return binding_affinities
-
-        with tempfile.TemporaryDirectory() as batch_dir:
-            batches = BindingAffinities.split_fasta_into_batches(
-                fa_file, batch_dir)
-            num_batches = len(batches)
-
-            for batch_idx, (batch_file, offset) in enumerate(batches):
-                if num_batches > 1:
-                    print(f'    batch {batch_idx + 1}/{num_batches} - '
-                          f'allele:{allele} epilen:{epilen} group:{group}',
-                          flush=True)
-
-                call = BindingAffinities._build_call(
-                    batch_file, allele, epilen, mhc_class)
-                batch_results = BindingAffinities._run_prediction(
-                    call, batch_file, group, mhc_class)
-
-                # the prediction tool numbers each batch file from 1; translate
-                # the per-batch sequence number to a global one. Global seqnums
-                # are unique across batches, so a plain assignment suffices.
-                for seqnum in batch_results:
-                    binding_affinities[offset + seqnum] = batch_results[seqnum]
-
-        return binding_affinities
     
     @staticmethod
     def calc_ranking_score(vaf, wt_ic50, mt_ic50):


### PR DESCRIPTION
## Summary
### Changed
- **Flatten binding-affinity prediction into a single thread pool.** `collect_binding_affinities` ran `len(alleles) × len(epilens)` tasks, each processing its FASTA batches *sequentially*, and `start()` called it twice (wt, then mt) — so concurrency was capped at `min(threads, alleles × epilens)` (e.g. 12 for a 3-allele, 4-length run), regardless of how many threads were allocated.
- `collect_binding_affinities` and `calc_binding_affinities` are replaced by one orchestrator: it splits every `(group, epilen)` FASTA up front, enumerates every `(group, allele, epilen, batch)` unit, and runs them all in a single `ThreadPoolExecutor`. `start()` calls it once for both wt and mt. Concurrency becomes `min(threads, total_batches)` — for a few-allele sample on a large node, ~12 → ~100+ concurrent netMHCpan.
- **Behaviour-preserving:** `_run_prediction`, `_build_call`, `split_fasta_into_batches` are unchanged; the per-batch computation, the `offset + seqnum` global keying (#111), and the cross-allele epitope merge are all preserved — the output is identical, only the scheduling changes.

Closes #113

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] `py_compile` passes (verified under the prioritization env Python 3.7)
- [ ] Output unchanged vs pre-#113 — to be confirmed by the combined v0.3.13 prioritization SLURM test (a re-run's `*_neoepitopes.txt` should be unchanged, modulo row order)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved binding affinity calculation efficiency through consolidated processing and optimized batch orchestration with concurrent execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ylab-hi/ScanNeo2/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
