### PR TITLE
Release v0.3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.13] - 2026-05-22
+
 ### Changed
 
 - **Parallelize binding-affinity prediction in one thread pool**: `collect_binding_affinities` previously ran `len(alleles) × len(epilens)` tasks — each processing its FASTA batches sequentially — and was called once for wt then once for mt, capping concurrency at `min(threads, alleles × epilens)` (e.g. 12 for a 3-allele, 4-length run) regardless of the allocated thread count. It and `calc_binding_affinities` are replaced by a single orchestrator that enumerates every `(group, allele, epitope-length, FASTA-batch)` unit and runs them all in one `ThreadPoolExecutor`, so concurrency scales with `min(threads, total_batches)`. The per-batch computation, global-seqnum keying and cross-allele merge are unchanged — output is identical, only the scheduling differs. ([#113](https://github.com/ylab-hi/ScanNeo2/issues/113), [#118](https://github.com/ylab-hi/ScanNeo2/pull/118))


### PR DESCRIPTION
## Summary

Rolls `[Unreleased]` into `## [0.3.13] - 2026-05-22`. CHANGELOG-only — no code changes. Tag `v0.3.13` after merge.

A prioritization-only bump.

### Included since v0.3.12

**Changed**
- Parallelize binding-affinity prediction in one thread pool ([#113](https://github.com/ylab-hi/ScanNeo2/issues/113), [#118](https://github.com/ylab-hi/ScanNeo2/pull/118))

**Fixed**
- Re-enable the variant-overlap filter so prioritization emits only variant-spanning epitopes ([#108](https://github.com/ylab-hi/ScanNeo2/issues/108), [#114](https://github.com/ylab-hi/ScanNeo2/pull/114))

Both prioritization changes are to be verified end-to-end by a combined `hlatest` SLURM re-run after the bump.

## QC
- [ ] I, as a human being, have checked each line of code in this pull request
- [x] CHANGELOG `[0.3.13]` entries match the PRs merged since v0.3.12 (#114, #118)