### PR TITLE
Release v0.3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.14] - 2026-05-24
+
 ### Refactored
 
 - **Reformat the remaining 13 Snakemake files with `snakefmt 2.0.0`**: mechanical pass (indent 2→4 space, single→double quotes, directive sort, trailing commas, long-line wrap) across `workflow/Snakefile` and every rule file not already cleaned by #124. With this PR the whole 17-file workflow tree is `snakefmt --check` clean. No behavior change; verified end-to-end by `snakefmt --check workflow/`, `snakemake --lint`, and `snakemake --dry-run`. ([#123](https://github.com/ylab-hi/ScanNeo2/issues/123), [#126](https://github.com/ylab-hi/ScanNeo2/pull/126))


### PR DESCRIPTION
## Summary
### Changed

Cuts the **v0.3.14** patch release. `## [Unreleased]` is split into `## [0.3.14] - 2026-05-24` plus a fresh empty `## [Unreleased]` block; no code changes.

## Highlights from this release

**Catalog compliance & static analysis (closes #115, #123):**
- `snakemake --lint` now exits 0 on the default placeholder config (#122).
- `snakefmt 2.0.0` runs cleanly across the whole 17-file workflow tree (#124, #126); CI's `formatting` job is a dedicated pinned `snakefmt` step replacing super-linter, with `permissions: contents: read` and `persist-credentials: false` hardening.
- The Snakemake Workflow Catalog `.snakemake-workflow-catalog.yml` was malformed (no top-level `usage:` key, deprecated `singularity` naming) — fixed; `config/README.md` rewritten from a wiki-pointer into a self-contained per-section parameter reference (#125).

**Env / dependency consolidation (partially closes #105):**
- Dead `picard.yml` env deleted; `realign.yml` (strict subset of `basic.yml`) merged in (#128).
- 8 single-command bcftools shell rules → `v4.0.0/bio/bcftools/{index,concat}` wrappers; SLURM-verified byte-identical merged VCFs (#129).
- `samtools.yml` bumped from 1.14 → 1.20, aligning with the `v4.0.0` wrapper pin (#132). SLURM-tested.

**UX + correctness fixes:**
- Friendlier config errors: `handle_seqfiles` / `data_structure` now fail fast with `[config error] file(s) not found: <path>` when a configured input path doesn't exist on disk (closes #130, #134).
- Run-summary banner now matches the configured MHC class — only prints MHC-I or MHC-II columns when actually configured (closes #131, #134).
- `valid_paired_end` regex was matching `file1` twice instead of `file1`+`file2` (#124, surfaced during snakefmt review).
- `preproc_paired_end` had `dapters=""` typo for the fastp wrapper's `adapters` param (#126, surfaced during snakefmt review).

## Open work moved out of v0.3.14

The 3 issues remaining open on v0.3.14 have been moved to **v0.3.15**:
- #105 — remaining samtools-version sprawl across other envs
- #116 — NMD detection across all variant sources
- #127 — document the hardcoded `threads: 10` choice in `align.smk:split_bamfile_RG`

`#133` (deferred wrapper conversion of single-command samtools rules) and the v0.4.x items (#117 protein input, #135 pre-execution failure audit) remain on their respective milestones.

## QC
- [x] I, as a human being, have reviewed this CHANGELOG cut
- [x] CI all green
- [x] `## [Unreleased]` is empty and `## [0.3.14] - 2026-05-24` is populated correctly
- [ ] After merge: tag `v0.3.14`, push tag, publish GitHub release with the CHANGELOG `[0.3.14]` section as the release notes, close the v0.3.14 milestone
