### PR TITLE
Rewrite multi-line params extras as adjacent string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Make multi-line `params: extra=...` blocks snakefmt-cross-version compatible**: the Snakemake Workflow Catalog pins `snakefmt 0.11.5` while our CI pins `2.0.0`, and the two versions indent backslash-continued multi-line strings inside `params:` differently — so a tree clean under one version fails the other's `--check`. Three rules (`star_align_fastq`, `star_align_bamfile`, `filter_short_indels_m2`) rewritten as adjacent string literals inside `(...)`, eliminating the multi-line continuation entirely; both snakefmt versions now agree the file is clean. The argument string passed to each wrapper is identical (modulo single-spacing between args). ([#139](https://github.com/ylab-hi/ScanNeo2/pull/139))
+
 ### Changed
 
 - **Audit hardcoded `threads:` values; cap and couple to `{threads}`** — 10 rules across `align.smk`, `altsplicing.smk`, `hlatyping_mhcI.smk`, `hlatyping_mhcII.smk`, `quantification.smk`. The most impactful change is **`hlatyping_mhcI_SE/PE` dropping from `threads: 64` to `threads: 1`** — OptiType is single-threaded (ILP solver; the wrapper does not parallelise across cores), so reserving 64 cores per invocation was serializing the downstream workflow for nothing. Other changes: `split_bamfile_RG` capped at `min(10, config["threads"])` (samtools split is I/O-bound; closes #127); `spladder` → `config["threads"]`; `filter_reads_mhcII_SE/PE` → `max(2, config["threads"])` to enforce bowtie2's two-thread minimum; `countfeatures` → `threads: 4`; `dnaseq_postproc` → `threads: 4` (samtools threading plateaus past ~4); and `rnaseq_postproc_fixmate` / `rnaseq_postproc_markdup` / `dnaseq_postproc` have their literal `-@N` shell arguments coupled to `-@ {threads}` so the directive value is what samtools actually receives. ([#127](https://github.com/ylab-hi/ScanNeo2/issues/127), [#138](https://github.com/ylab-hi/ScanNeo2/pull/138))

--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -17,24 +17,26 @@ if (
             "logs/{sample}/align/star_align_fastq_{group}.log",
         threads: config["threads"]
         params:
-            extra=lambda wildcards: f"""--outSAMtype BAM Unsorted \
-          --genomeSAindexNbases 10 \
-          --outSAMattributes RG HI \
-          --outSAMattrRGline ID:{wildcards.group} \
-          --outFilterMultimapNmax 50 \
-          --peOverlapNbasesMin 15 \
-          --alignSplicedMateMapLminOverLmate 0.5 \
-          --alignSJstitchMismatchNmax 5 -1 5 5 \
-          --chimOutType WithinBAM HardClip \
-          --chimSegmentMin {config["align"]["chimSegmentMin"]} \
-          --chimJunctionOverhangMin {config["align"]["chimJunctionOverhangMin"]} \
-          --chimScoreDropMax {config["align"]["chimScoreDropMax"]} \
-          --chimScoreMin {config["align"]["chimScoreMin"]} \
-          --chimScoreJunctionNonGTAG 0 \
-          --chimScoreSeparation {config["align"]["chimScoreSeparation"]} \
-          --chimSegmentReadGapMax 3 \
-          --chimMultimapNmax 50 \
-          --outSAMstrandField intronMotif""",
+            extra=lambda wildcards: (
+                "--outSAMtype BAM Unsorted "
+                "--genomeSAindexNbases 10 "
+                "--outSAMattributes RG HI "
+                f"--outSAMattrRGline ID:{wildcards.group} "
+                "--outFilterMultimapNmax 50 "
+                "--peOverlapNbasesMin 15 "
+                "--alignSplicedMateMapLminOverLmate 0.5 "
+                "--alignSJstitchMismatchNmax 5 -1 5 5 "
+                "--chimOutType WithinBAM HardClip "
+                f"--chimSegmentMin {config['align']['chimSegmentMin']} "
+                f"--chimJunctionOverhangMin {config['align']['chimJunctionOverhangMin']} "
+                f"--chimScoreDropMax {config['align']['chimScoreDropMax']} "
+                f"--chimScoreMin {config['align']['chimScoreMin']} "
+                "--chimScoreJunctionNonGTAG 0 "
+                f"--chimScoreSeparation {config['align']['chimScoreSeparation']} "
+                "--chimSegmentReadGapMax 3 "
+                "--chimMultimapNmax 50 "
+                "--outSAMstrandField intronMotif"
+            ),
         message:
             "Aligning reads from {wildcards.group} to genome using STAR"
         wrapper:
@@ -95,22 +97,24 @@ if config["data"]["rnaseq_filetype"] == ".bam":
             "logs/{sample}/align/star_align_bamfile_{group}_{rg}.log",
         threads: config["threads"]
         params:
-            extra=lambda wildcards: f"""--outSAMtype BAM Unsorted --genomeSAindexNbases 10 \
-        --readFilesCommand zcat \
-        --outSAMattributes RG HI --outSAMattrRGline ID:{wildcards.rg} \
-        --outFilterMultimapNmax 50 \
-        --peOverlapNbasesMin 15 \
-        --alignSplicedMateMapLminOverLmate 0.5 \
-        --alignSJstitchMismatchNmax 5 -1 5 5 \
-        --chimOutType WithinBAM HardClip \
-        --chimSegmentMin {config["align"]["chimSegmentMin"]} \
-        --chimJunctionOverhangMin {config["align"]["chimJunctionOverhangMin"]} \
-        --chimScoreDropMax {config["align"]["chimScoreDropMax"]} \
-        --chimScoreMin {config["align"]["chimScoreMin"]} \
-        --chimScoreJunctionNonGTAG 0 \
-        --chimScoreSeparation {config["align"]["chimScoreSeparation"]} \
-        --chimSegmentReadGapMax 3 --chimMultimapNmax 50 \
-        --outSAMstrandField intronMotif""",
+            extra=lambda wildcards: (
+                "--outSAMtype BAM Unsorted --genomeSAindexNbases 10 "
+                "--readFilesCommand zcat "
+                f"--outSAMattributes RG HI --outSAMattrRGline ID:{wildcards.rg} "
+                "--outFilterMultimapNmax 50 "
+                "--peOverlapNbasesMin 15 "
+                "--alignSplicedMateMapLminOverLmate 0.5 "
+                "--alignSJstitchMismatchNmax 5 -1 5 5 "
+                "--chimOutType WithinBAM HardClip "
+                f"--chimSegmentMin {config['align']['chimSegmentMin']} "
+                f"--chimJunctionOverhangMin {config['align']['chimJunctionOverhangMin']} "
+                f"--chimScoreDropMax {config['align']['chimScoreDropMax']} "
+                f"--chimScoreMin {config['align']['chimScoreMin']} "
+                "--chimScoreJunctionNonGTAG 0 "
+                f"--chimScoreSeparation {config['align']['chimScoreSeparation']} "
+                "--chimSegmentReadGapMax 3 --chimMultimapNmax 50 "
+                "--outSAMstrandField intronMotif"
+            ),
         wrapper:
             "v2.2.1/bio/star/align"
 

--- a/workflow/rules/indel.smk
+++ b/workflow/rules/indel.smk
@@ -211,14 +211,16 @@ rule filter_short_indels_m2:
     resources:
         mem_mb=1024,
     params:
-        extra=f"""--max-alt-allele-count 3 \
-      --min-median-base-quality {config['basequal']} \
-      --min-median-mapping-quality {config['mapq']} \
-      --threshold-strategy {config['indel']['strategy']} \
-      --f-score-beta {config['indel']['fscorebeta']} \
-      --false-discovery-rate {config['indel']['fdr']} \
-      --pcr-slippage-rate {config['indel']['sliprate']} \
-      --min-slippage-length {config['indel']['sliplen']}""",
+        extra=(
+            "--max-alt-allele-count 3 "
+            f"--min-median-base-quality {config['basequal']} "
+            f"--min-median-mapping-quality {config['mapq']} "
+            f"--threshold-strategy {config['indel']['strategy']} "
+            f"--f-score-beta {config['indel']['fscorebeta']} "
+            f"--false-discovery-rate {config['indel']['fdr']} "
+            f"--pcr-slippage-rate {config['indel']['sliprate']} "
+            f"--min-slippage-length {config['indel']['sliplen']}"
+        ),
         java_opts="",  # optional
     message:
         "Filtering somatic SNVs/Indels with FilterMutectCalls on sample:{wildcards.sample} with group:{wildcards.group} on chromosome {wildcards.chr}"


### PR DESCRIPTION
## Summary
### Fixed

The Snakemake Workflow Catalog page for ScanNeo2 reports a `formatting: failed` status because `snakefmt 0.11.5` (the version pinned by the catalog at `>=0.11.5,<0.12`) and `snakefmt 2.0.0` (the version our CI pins, since #124) disagree on how to indent continuation lines inside multi-line `params: extra=f"""..."""` blocks. A tree formatted for one version fails the other's `--check`.

Three rule params blocks rewritten as **adjacent string literals inside `(...)`** — Python's implicit string concatenation. This eliminates the multi-line continuation entirely, so there's nothing left for the two snakefmt versions to disagree about:

- `align.smk:star_align_fastq` (STAR fastq path)
- `align.smk:star_align_bamfile` (STAR BAM path)
- `indel.smk:filter_short_indels_m2` (FilterMutectCalls)

The command line passed to each wrapper is identical to before (modulo single-spacing between args, which the shell parses equivalently).

## Verified locally

- `snakefmt 0.11.5 --check workflow/` → **all 17 files clean** (catalog-aligned).
- `snakefmt 2.0.0 --check workflow/` → **all 17 files clean** (CI-aligned).
- `snakemake --lint --configfile config/config.yaml` → exits 0.
- `snakemake --configfile config/config.yaml --dry-run` → friendly `[config error]` from the default-empty data section; proves the new f-string evaluates without runtime errors.

## Upstream follow-up

I'm filing a separate issue on `snakemake/snakemake-workflow-catalog` asking them to consider bumping their snakefmt pin — long-term, the catalog being on a 2-year-old version is the real problem that this PR papers over.

## QC
- [x] I, as a human being, have reviewed each of the 3 rewrites
- [x] `snakefmt --check workflow/` clean under **both** `0.11.5` (catalog) and `2.0.0` (our CI)
- [x] `snakemake --lint --configfile config/config.yaml` exits 0
- [x] CI all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code formatting in alignment and variant filtering workflow rules for better readability and maintainability while preserving all existing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ylab-hi/ScanNeo2/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
