### PR TITLE
Release v0.3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.15] - 2026-05-25
+
 ### Changed
 
 - **Improve prioritization log readability per-vartype**: `BindingAffinities.start` / `collect_binding_affinities` in `workflow/scripts/prioritization/prediction.py` now print a banner header (`=== somatic.snvs ===`) at the start of each vartype, throttle the per-unit progress line to ~10 messages per vartype (`step = max(1, total // 10)`, always emits the final), and replace the bare `Done` with a closing summary line `[<vartype>] done in X.X min`. Reduces a ~2000-line prioritization log to ~30 useful lines plus 3 clean section boundaries. Also removes two leftover debug `print()` calls in `reference.py:Counts.__init__` that were dumping the count-table header columns and group slice on every run. Closes #121. ([#121](https://github.com/ylab-hi/ScanNeo2/issues/121), [#140](https://github.com/ylab-hi/ScanNeo2/pull/140))
+- **Audit hardcoded `threads:` values; cap and couple to `{threads}`** — 10 rules across `align.smk`, `altsplicing.smk`, `hlatyping_mhcI.smk`, `hlatyping_mhcII.smk`, `quantification.smk`. The most impactful change is **`hlatyping_mhcI_SE/PE` dropping from `threads: 64` to `threads: 1`** — OptiType is single-threaded (ILP solver; the wrapper does not parallelise across cores), so reserving 64 cores per invocation was serializing the downstream workflow for nothing. Other changes: `split_bamfile_RG` capped at `min(10, config["threads"])` (samtools split is I/O-bound; closes #127); `spladder` → `config["threads"]`; `filter_reads_mhcII_SE/PE` → `max(2, config["threads"])` to enforce bowtie2's two-thread minimum; `countfeatures` → `threads: 4`; `dnaseq_postproc` → `threads: 4` (samtools threading plateaus past ~4); and `rnaseq_postproc_fixmate` / `rnaseq_postproc_markdup` / `dnaseq_postproc` have their literal `-@N` shell arguments coupled to `-@ {threads}` so the directive value is what samtools actually receives. ([#127](https://github.com/ylab-hi/ScanNeo2/issues/127), [#138](https://github.com/ylab-hi/ScanNeo2/pull/138))
 
 ### Fixed
 
 - **Make multi-line `params: extra=...` blocks snakefmt-cross-version compatible**: the Snakemake Workflow Catalog pins `snakefmt 0.11.5` while our CI pins `2.0.0`, and the two versions indent backslash-continued multi-line strings inside `params:` differently — so a tree clean under one version fails the other's `--check`. Three rules (`star_align_fastq`, `star_align_bamfile`, `filter_short_indels_m2`) rewritten as adjacent string literals inside `(...)`, eliminating the multi-line continuation entirely; both snakefmt versions now agree the file is clean. The argument string passed to each wrapper is identical (modulo single-spacing between args). ([#139](https://github.com/ylab-hi/ScanNeo2/pull/139))
-
-### Changed
-
-- **Audit hardcoded `threads:` values; cap and couple to `{threads}`** — 10 rules across `align.smk`, `altsplicing.smk`, `hlatyping_mhcI.smk`, `hlatyping_mhcII.smk`, `quantification.smk`. The most impactful change is **`hlatyping_mhcI_SE/PE` dropping from `threads: 64` to `threads: 1`** — OptiType is single-threaded (ILP solver; the wrapper does not parallelise across cores), so reserving 64 cores per invocation was serializing the downstream workflow for nothing. Other changes: `split_bamfile_RG` capped at `min(10, config["threads"])` (samtools split is I/O-bound; closes #127); `spladder` → `config["threads"]`; `filter_reads_mhcII_SE/PE` → `max(2, config["threads"])` to enforce bowtie2's two-thread minimum; `countfeatures` → `threads: 4`; `dnaseq_postproc` → `threads: 4` (samtools threading plateaus past ~4); and `rnaseq_postproc_fixmate` / `rnaseq_postproc_markdup` / `dnaseq_postproc` have their literal `-@N` shell arguments coupled to `-@ {threads}` so the directive value is what samtools actually receives. ([#127](https://github.com/ylab-hi/ScanNeo2/issues/127), [#138](https://github.com/ylab-hi/ScanNeo2/pull/138))
 
 ## [0.3.14] - 2026-05-24
 


### PR DESCRIPTION
## Summary
### Changed

Cuts the **v0.3.15** patch release. `## [Unreleased]` is split into `## [0.3.15] - 2026-05-25` plus a fresh empty `## [Unreleased]` block; the two `### Changed` subsections (separated by `### Fixed` from the merge order) are consolidated. No code changes.

## Highlights from this release

**Performance / threading audit (closes #127):**
- Hardcoded `threads:` values across 10 rules audited and either capped or coupled to `{threads}` in shell. Most impactful: `hlatyping_mhcI_SE/PE` dropped from `threads: 64` to `threads: 1` because OptiType is single-threaded (ILP solver; wrapper never passes a threads arg to the tool) — the previous 64 was forcing snakemake to reserve cores the tool never used and serializing the downstream workflow (#138).
- `split_bamfile_RG` capped at `min(10, config["threads"])`; `dnaseq_postproc` dropped from 6→4 (samtools threading plateaus past ~4); `rnaseq_postproc_*` shell `-@N` literals coupled to `-@ {threads}` so the directive value is what samtools actually receives.

**Catalog snakefmt cross-version compatibility:**
- Three multi-line `params: extra=f"""..."""` blocks (STAR alignments + FilterMutectCalls) rewritten as adjacent-string-literal `(...)` form, eliminating the indent disagreement between `snakefmt 0.11.5` (catalog) and `2.0.0` (our CI) that was keeping the catalog's `formatting: failed` flag on (#139).

**Log readability (closes #121):**
- Prioritization step now prints a banner header per vartype (`=== somatic.snvs ===`), throttles the per-unit progress to ~10 lines instead of 2000+, and emits a wall-clock summary at vartype completion. Two leftover debug `print()` calls in `reference.py:Counts.__init__` removed (#140).

## Open work moved out of v0.3.15

#116 (NMD detection for all variant sources) was moved to **ScanNeo v0.4.x** after investigation surfaced a deeper bug: the non-fusion transcript construction uses pre-mRNA (intron-inclusive genome slice) rather than spliced mRNA. The full engineering plan for the proper fix is preserved as a comment on #116.

## QC
- [x] I, as a human being, have reviewed this CHANGELOG cut
- [x] CI all green
- [x] `## [Unreleased]` is empty and `## [0.3.15] - 2026-05-25` is populated correctly with the consolidated sections
- [ ] After merge: tag `v0.3.15`, push tag, publish GitHub release with the CHANGELOG `[0.3.15]` section as the release notes, close the v0.3.15 milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved workflow compatibility issues across different formatting tool versions.

* **Chores**
  * Improved logging output formatting and progress reporting.
  * Optimized workflow thread configuration for better resource utilization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ylab-hi/ScanNeo2/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
