### PR TITLE
NMD detection for all frameshift variants via spliced mRNA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Extend NMD detection to all frameshift variants via spliced mRNA**: non-fusion variants (SNV / short-indel / long-indel / exitron / alt-splicing) had `NMD`, `PTC_exon_number`, `PTC_dist_ejc`, `NMD_escape_rule` silently empty in `*_variant_effects.tsv`. The pre-existing `variants.py` constructed a "transcript" by genomic-slicing from transcript-start to transcript-end (introns included); `effects.py:find_stop_codon` then walked this pre-mRNA and typically hit a spurious in-frame stop in the first intron downstream of the variant, which `annotate_stop_codon` dropped as non-exonic — leaving the NMD columns blank. New strand-aware spliced-mRNA + genomic↔mRNA mapping layer on `Annotation` (`exon_map`, `splice_transcript`, `genomic_to_mrna`, `mrna_to_genomic`, `splice_with_variant`); `variants.py` uses it; `effects.py:find_stop_codon` / `annotate_stop_codon` / `check_escape` operate on mRNA-relative coords with strand awareness (rules 2 and 3 in `check_escape` were `+`-strand-only as written); the VEP `field["NMD"]` pre-filter is removed so every frameshift reaches `determine_NMD`. Both GTF parsers (`parse_transcriptome`, `parse_exome`) standardised on 0-based half-open coords; fusion path shifts the arriba 1-based seg2 breakpoint by -1 to compensate, preserving existing fusion behaviour. Verified on a real LNCaP run (`hlatest_PR130-131`): 2277/2277 short-indel frameshifts now reach `determine_NMD`; 1101 receive a meaningful NMD verdict with balanced `+`/`-` strand counts across escape rules 1/3/4; 48,436 mhc-I neoepitopes produced end-to-end. ([#116](https://github.com/ylab-hi/ScanNeo2/issues/116), [#142](https://github.com/ylab-hi/ScanNeo2/pull/142))
+
 ## [0.3.15] - 2026-05-25
 
 ### Changed

--- a/workflow/scripts/prioritization/effects.py
+++ b/workflow/scripts/prioritization/effects.py
@@ -164,7 +164,7 @@ class VariantEffects:
                 return
             seg2_bp_0based = int(self.data["start"].split('|')[1]) - 1
             stop_coord = seg2_bp_0based + (stop_pos - cds_bp)
-            # Arriba doesn't expose strand here; assume + (existing behaviour).
+            # Arriba doesn't expose strand directly; assume +.
             strand = '+'
         else:
             tid = self.data["transcript_id"]

--- a/workflow/scripts/prioritization/effects.py
+++ b/workflow/scripts/prioritization/effects.py
@@ -17,7 +17,8 @@ from pathlib import Path
 class VariantEffects:
     def __init__(self, options, vartype):
 
-        self.exome = reference.Annotation(options.reference, options.anno).exome
+        self.annotation = reference.Annotation(options.reference, options.anno)
+        self.exome = self.annotation.exome
         self.counts = reference.Counts(options.counts).counts
         self.data = {}
 
@@ -127,7 +128,6 @@ class VariantEffects:
         self.data["wt_subseq"] = self.data["wt_seq"][left:right+1]
         self.data["mt_subseq"] = self.data["mt_seq"][left:right+1]
 
-    # TODO: check for NMD out of VEP
     def determine_NMD(self, nmd_event):
         if nmd_event is not None:
             self.data["NMD"] = nmd_event
@@ -139,154 +139,141 @@ class VariantEffects:
         self.data["NMD_escape_rule"] = None
 
         transcript = self.data["transcript"]
-        # only need to be considered for framshift events
-        if "frameshift" in self.data["var_type"]:
-            # transcript is required to determine NMD
-            if transcript is not None: 
-                transcript_bp = int(self.data["transcript_bp"])
-                start = self.data["start"]
+        if "frameshift" not in self.data["var_type"] or transcript is None:
+            return
+        if self.data["transcript_id"] is None:
+            return
 
-                """ determine the coding sequence and adjust the breakpoint 
-                (considering the adjusted startpos, e.g., start codon)"""
-                cds, cds_bp = self.determine_cds(transcript,
-                                                 transcript_bp)
+        transcript_bp = int(self.data["transcript_bp"])
+        cds, cds_bp, start_codon_offset = self.determine_cds(transcript,
+                                                              transcript_bp)
+        if cds is None:
+            return
 
-                if cds is not None: # when the start codon could be found
-                    """determine the genomic coordinate of the breakpoint -
-                    consider start of segment 2 in fusion transcripts"""
-                    """determine the genomic coordinate of the cds breakpoint 
-                    - note: in fusion events this the start of the segment 2. 
-                    We can use this since self.data["transcript_bp"] corresponds 
-                    to seg2 in start"""
-                    if self.data["source"] == "fusion":
-                        bp_coord = int(start.split('|')[1])
-                    else:
-                        bp_coord = int(start) + transcript_bp + 1
+        stop_pos = self.find_stop_codon(cds, cds_bp)
+        if stop_pos == -1:
+            return
 
-                    # search for stop_codon
-                    stop_pos, stop_coord = self.find_stop_codon(cds,
-                                                                cds_bp,
-                                                                bp_coord)
+        if self.data["source"] == "fusion":
+            # Fusion: arriba reports segment-2's genomic breakpoint as a 1-based
+            # position; shift to 0-based to match the exon table convention.
+            # The transcript is already spliced by arriba so linear arithmetic
+            # past the breakpoint is correct within segment 2.
+            tid = self.data["transcript_id"].split('|')[1]
+            if tid == '.':
+                return
+            seg2_bp_0based = int(self.data["start"].split('|')[1]) - 1
+            stop_coord = seg2_bp_0based + (stop_pos - cds_bp)
+            # Arriba doesn't expose strand here; assume + (existing behaviour).
+            strand = '+'
+        else:
+            tid = self.data["transcript_id"]
+            # CDS position → mRNA position → genomic coord (strand-aware).
+            mrna_stop = stop_pos + start_codon_offset + 3
+            stop_coord = self.annotation.mrna_to_genomic(tid, mrna_stop)
+            if stop_coord is None:
+                return
+            strand = self.annotation.transcriptome[tid][2]
 
-                    # check of stop_codon is PTC
-                    if stop_pos != -1:
-                        if self.data["transcript_id"] is not None:
-                            if self.data["source"] == "fusion":
-                                """ needs to be tid in 2nd transcript - mainly
-                                because this is where the PTC is supposed to be"""
-                                tid = self.data["transcript_id"].split('|')[1]
-                                if tid == '.':
-                                    return
-                            else:
-                                tid = self.data["transcript_id"]
+        exoninfo = self.exome[tid]
+        exons = list(exoninfo.keys())
 
-                            exoninfo = self.exome[tid]
-                            exons = list(exoninfo.keys())
+        exon_num, dist_ejc = self.annotate_stop_codon(exoninfo, stop_coord, strand)
+        if exon_num == -1:
+            return
 
-                            exon_num, dist_ejc = self.annotate_stop_codon(exoninfo,
-                                                                          stop_coord)
+        self.data["PTC_exon_number"] = f'{exon_num}'
+        if max(exons) > 1:
+            self.data["PTC_dist_ejc"] = dist_ejc
 
-                            if exon_num != -1:
-                                self.data["PTC_exon_number"] = f'{exon_num}'
-                                if max(exons) > 1:
-                                    self.data["PTC_dist_ejc"] = dist_ejc
-
-                                nmd_escape = self.check_escape(exoninfo,
-                                                               stop_coord,
-                                                               exon_num,
-                                                               dist_ejc)
-
-                                if nmd_escape != -1:
-                                    self.data["NMD"] = "NMD_escaping_variant"
-                                    self.data["NMD_escape_rule"] = nmd_escape
-                                else:
-                                    self.data["NMD"] = "NMD_variant"
+        nmd_escape = self.check_escape(exoninfo, stop_coord, exon_num,
+                                       dist_ejc, strand)
+        if nmd_escape != -1:
+            self.data["NMD"] = "NMD_escaping_variant"
+            self.data["NMD_escape_rule"] = nmd_escape
+        else:
+            self.data["NMD"] = "NMD_variant"
 
 
     
     @staticmethod
     def determine_cds(transcript, transcript_bp):
-        """ determines the coding sequence of the transcript - 
-        return coding sequence (cds) and its breakpoint within the cds
-        (cds_bp) and its genomic coordinate (cds_bp_global)"""
+        """Locate the start codon in `transcript` and return the CDS plus the
+        breakpoint's position within it.
 
+        Returns (cds, cds_bp, start_codon_offset) where `start_codon_offset`
+        is the 0-based mRNA position of the ATG, so that
+        `mrna_pos == cds_pos + start_codon_offset + 3`. Returns
+        (None, None, None) if no usable start codon precedes the breakpoint.
+        """
         start_codon = re.search(r'ATG', transcript)
-        if start_codon:
-            """start codon has to occur before the breakpoint 
-            - note the breakpoint corresponds to the local site"""
-            if start_codon.start() < transcript_bp:
-                # determines the cds - start after start codon...
-                cds = transcript[start_codon.start()+3:]
-                # ... and the breakpoint position within the cds
-                cds_bp = transcript_bp - (start_codon.start() + 3)
-                # """determine the genomic coordinate of the cds breakpoint 
-                # - note: in fusion events this the start of the segment 2. 
-                # We can use this since self.data["transcript_bp"] corresponds to 
-                # start(seg1|seg2)"""
-                # start = self.data["start"]
-                # if self.data["source"] == "fusion":
-                    # # in fusion events this contains the starts of both segments
-                    # cds_bp_coord = start.split('|')[1]
-                # else:
-                    # cds_cp_coord = start + self.data["transcript_bp"] + 1
-                return cds, cds_bp
-            else:
-                return None, None
-        else:
-            return None, None
+        if start_codon and start_codon.start() < transcript_bp:
+            offset = start_codon.start()
+            cds = transcript[offset+3:]
+            cds_bp = transcript_bp - (offset + 3)
+            return cds, cds_bp, offset
+        return None, None, None
 
 
     @staticmethod
-    def find_stop_codon(cds, bp, bp_coord):
-        """search for stop codon in coding sequence returns 0-based index
-
-        the stop codon and 
-        genomic coordinate of the end of the second segment
-        """
+    def find_stop_codon(cds, bp):
+        """Return the 0-based CDS-relative position of the first in-frame stop
+        codon strictly downstream of bp, or -1 if none. The caller is
+        responsible for converting this CDS position into a genomic coordinate
+        (strand-aware for non-fusion; linear arithmetic for fusion)."""
         stop_pos = -1
         for i in range(0, len(cds), 3):
             codon = cds[i:i+3]
             if codon == "TAA" or codon == "TAG" or codon == "TGA":
-                stop_pos = i # stop codon has been found
+                stop_pos = i
                 break
 
-        # stop codon shouldn't be found before the actual mutant in transcript
         if stop_pos <= bp:
-            return -1, -1
-        else:
-            return stop_pos, bp_coord + (stop_pos - bp)  
+            return -1
+        return stop_pos
 
 
-    def annotate_stop_codon(self, exoninfo, stop_coord):
-        stop_exon = -1
+    def annotate_stop_codon(self, exoninfo, stop_coord, strand):
+        """Locate which exon holds the PTC and report `dist_ejc`, the number of
+        bases between the PTC and the 3' end of that exon in transcript
+        orientation. Coordinates are 0-based half-open."""
         for exon_number in exoninfo:
-            exon_start = int(exoninfo[exon_number][0])
-            exon_end = int(exoninfo[exon_number][1])
-            if stop_coord >= exon_start and stop_coord <= exon_end:
-                stop_exon = exon_number
-                dist_ejc = exon_end - stop_coord
-                return stop_exon, dist_ejc
+            exon_start, exon_end = exoninfo[exon_number]
+            if exon_start <= stop_coord < exon_end:
+                if strand == '+':
+                    dist_ejc = (exon_end - 1) - stop_coord
+                else:
+                    dist_ejc = stop_coord - exon_start
+                return exon_number, dist_ejc
 
-        # no exon information found for stop_codon
         return -1, -1
 
 
-    def check_escape(self, exoninfo, stop_coord, exon_num, dist_ejc):
-        """ 
-        1. If the variant is in an intronless transcript, meaning only one exon exist in the transcript.
-        2. The variant falls in the first 100 coding bases in the transcript.
-             vvv
-          ..ES...EE..I.ES...EE.I.ES....EE.I.ES....EE 
-        (ES= exon_start,EE = exon_end, I = intron, v = variant location)
-        3. The variant location falls 50 bases upstream of the penultimate (second to the last) exon.
-                                   vvv
-          ES...EE..I.ES...EE.I.ES....EE.I.ES....EE 
-        (ES= exon_start,EE = exon_end, I = intron, v = variant location)
-        4. The variant location  falls in the last exon of the transcript.
-                                                vvvv
-              ES...EE..I.ES...EE.I.ES....EE.I.ES....EE 
-         (ES= exon_start,EE = exon_end, I = intron, v = variant location)
+    def check_escape(self, exoninfo, stop_coord, exon_num, dist_ejc, strand):
+        """Determine whether a PTC escapes NMD. Returns one of:
 
+          1 — Intronless transcript (only one exon). No downstream
+              exon-exon junction → no EJC for the NMD machinery to recruit.
+          2 — Start-proximal PTC, within 100 nt of the 5' end of exon 1 in
+              transcript orientation. Translation re-initiation downstream
+              can rescue the transcript.
+          3 — PTC within 50 nt of the last exon-exon junction (i.e. close to
+              the 3' end of the penultimate exon in transcript orientation).
+              The downstream EJC is removed during the first round of
+              translation before NMD can act.
+          4 — PTC in the last exon — no downstream EJC at all.
+         -1 — None of the above; NMD targets the transcript.
+
+        ASCII layout (transcript orientation, 5'→3'):
+
+          rule 2:   vvv
+                ..ES...EE..I.ES...EE.I.ES....EE.I.ES....EE
+          rule 3:                       vvv
+                  ES...EE..I.ES...EE.I.ES....EE.I.ES....EE
+          rule 4:                                    vvvv
+                  ES...EE..I.ES...EE.I.ES....EE.I.ES....EE
+
+        (ES = exon 5' end, EE = exon 3' end, I = intron, v = PTC.)
         """
         exons = list(exoninfo.keys())
         last_exon = int(max(exons))
@@ -295,14 +282,19 @@ class VariantEffects:
             if last_exon == 1: # there is only one exon
                 return 1
             elif last_exon > 1:
-                exon_start = int(exoninfo[1][0])
-                # check if PTC is within 
-                if stop_coord - exon_start < 100:
+                exon_start, exon_end = exoninfo[1]
+                # rule 2: PTC within 100 nt of the 5' end of exon 1 in
+                # transcript orientation
+                if strand == '+':
+                    dist_from_5p = stop_coord - exon_start
+                else:
+                    dist_from_5p = (exon_end - 1) - stop_coord
+                if dist_from_5p < 100:
                     return 2
         if exon_num == last_exon-1:
-            exon_start = int(exoninfo[last_exon-1][0])
-            exon_end = int(exoninfo[last_exon-1][1])
-            if exon_end - stop_coord <= 50:
+            # rule 3: PTC within 50 nt of the 3' end of the penultimate exon
+            # in transcript orientation — i.e. close to the last EJC
+            if dist_ejc <= 50:
                 return 3
         elif exon_num == last_exon:
             return 4

--- a/workflow/scripts/prioritization/reference.py
+++ b/workflow/scripts/prioritization/reference.py
@@ -7,6 +7,11 @@ transcriptome and exome coordinate maps, and `Counts` loads the per-gene express
 import pyfaidx
 import re
 
+COMPLEMENT = str.maketrans('ACGTNacgtn', 'TGCANtgcan')
+
+def revcomp(seq):
+    return seq.translate(COMPLEMENT)[::-1]
+
 class Proteome:
     def __init__(self, fastaFile):
         # parse proteome
@@ -24,10 +29,13 @@ class Proteome:
 class Annotation:
     def __init__(self, fastaFile, gtfFile):
         self.ref = pyfaidx.Fasta(fastaFile)
-        self.transcriptome = self.parse_transcriptome(gtfFile) 
+        self.transcriptome = self.parse_transcriptome(gtfFile)
         self.exome = self.parse_exome(gtfFile)
+        self.exon_map_cache = {}
 
-    # 0-based
+    # GTF coords are 1-based inclusive; we store 0-based half-open throughout
+    # (start inclusive, end exclusive) for direct compatibility with pyfaidx
+    # slicing and Python range semantics.
     def parse_transcriptome(self, gtfFile):
         transcriptome = {}
         with open(gtfFile, "r") as fh:
@@ -38,7 +46,7 @@ class Annotation:
                     if l[2] == "transcript":
                         transcript_id = re.search(r'transcript_id "([^.\s]+)"', l[8]).group(1)
                         if transcript_id not in transcriptome:
-                            transcriptome[transcript_id] = [int(l[3])-1, int(l[4])-1]
+                            transcriptome[transcript_id] = [int(l[3])-1, int(l[4]), l[6]]
 
         return transcriptome
 
@@ -59,9 +67,143 @@ class Annotation:
                             exome[transcript_id] = {}
 
                         if not exon_number in exome[transcript_id]:
-                            exome[transcript_id][int(exon_number)] = [l[3], l[4]]
+                            exome[transcript_id][int(exon_number)] = [int(l[3])-1, int(l[4])]
 
         return exome
+
+
+    def exon_map(self, transcript_id):
+        """Per-exon table in 5'→3' (mRNA) order.
+
+        GTF exon_number is by transcript position — exon 1 is always the first
+        exon transcribed, regardless of strand. Iterating ascending therefore
+        walks the mRNA from its 5' to 3' end on either strand.
+
+        Returns (strand, exons) where exons is a list of tuples
+        (mrna_start, mrna_end_excl, genomic_start, genomic_end_excl),
+        all 0-based half-open.
+        """
+        if transcript_id in self.exon_map_cache:
+            return self.exon_map_cache[transcript_id]
+
+        strand = self.transcriptome[transcript_id][2]
+        exoninfo = self.exome[transcript_id]
+        exons = []
+        mrna_cursor = 0
+        for n in sorted(exoninfo.keys()):
+            g_start, g_end = exoninfo[n]
+            length = g_end - g_start
+            exons.append((mrna_cursor, mrna_cursor + length, g_start, g_end))
+            mrna_cursor += length
+
+        result = (strand, exons)
+        self.exon_map_cache[transcript_id] = result
+        return result
+
+
+    def splice_transcript(self, transcript_id, chrom):
+        """Build the strand-aware spliced mRNA for a transcript.
+
+        For - strand transcripts each exon's forward-strand genomic sequence is
+        reverse-complemented before concatenation, so the returned mRNA reads
+        5'→3' in transcript orientation.
+
+        Returns (mrna, strand, exons) — exons as from exon_map.
+        """
+        strand, exons = self.exon_map(transcript_id)
+        pieces = []
+        for (_, _, g_start, g_end) in exons:
+            seq = str(self.ref[chrom][g_start:g_end])
+            if strand == '-':
+                seq = revcomp(seq)
+            pieces.append(seq)
+        return ''.join(pieces), strand, exons
+
+
+    def genomic_to_mrna(self, transcript_id, genomic_pos):
+        """Map a 0-based genomic position to a 0-based mRNA position.
+
+        Returns None if the position falls in an intron or outside the
+        transcript. For - strand, the mRNA position counts from the 5' end of
+        the transcript, which is the genomically-rightmost exon — so the
+        genomically-rightmost base of an exon is the 5'-most base of that
+        exon's mRNA chunk.
+        """
+        strand, exons = self.exon_map(transcript_id)
+        for (m_start, _, g_start, g_end) in exons:
+            if g_start <= genomic_pos < g_end:
+                if strand == '+':
+                    return m_start + (genomic_pos - g_start)
+                else:
+                    return m_start + (g_end - 1 - genomic_pos)
+        return None
+
+
+    def mrna_to_genomic(self, transcript_id, mrna_pos):
+        """Inverse of genomic_to_mrna. Returns a 0-based genomic position, or
+        None if mrna_pos is outside the transcript's spliced length."""
+        strand, exons = self.exon_map(transcript_id)
+        for (m_start, m_end, g_start, g_end) in exons:
+            if m_start <= mrna_pos < m_end:
+                offset = mrna_pos - m_start
+                if strand == '+':
+                    return g_start + offset
+                else:
+                    return g_end - 1 - offset
+        return None
+
+
+    def splice_with_variant(self, transcript_id, chrom,
+                             affected_start, affected_end, allele):
+        """Build the mutant spliced mRNA for a non-fusion variant.
+
+        Coordinates are 0-based half-open (vcfpy `affected_start`/`affected_end`
+        convention). `allele` is VEP's forward-strand `Allele` field: `'-'` for
+        pure deletion, the inserted bases (without anchor) for insertion, the
+        alt base(s) for SNV/MNV.
+
+        Returns (mt_mrna, var_mrna_start) — `var_mrna_start` is the 0-based
+        mRNA position of the first inserted/altered base in the mutant mRNA.
+        Returns (None, None) if the variant has no clean exonic representation
+        (intronic, or spans an exon-intron boundary).
+        """
+        mrna, strand, _ = self.splice_transcript(transcript_id, chrom)
+
+        is_insertion = (allele != '-' and affected_start == affected_end)
+        is_deletion  = (allele == '-')
+
+        if is_insertion:
+            # vcfpy reports affected_start = POS for insertions, i.e. the
+            # position one-past the anchor base on + strand. The anchor itself
+            # sits at affected_start - 1 (0-based genomic) and is unchanged.
+            m_anchor = self.genomic_to_mrna(transcript_id, affected_start - 1)
+            if m_anchor is None:
+                return None, None
+            alt = revcomp(allele) if strand == '-' else allele
+            # On + strand the inserted bases follow the anchor in mRNA order;
+            # on - strand they precede it (anchor's genomic neighbour at
+            # affected_start lies at mRNA position m_anchor - 1).
+            insert_at = m_anchor + 1 if strand == '+' else m_anchor
+            return mrna[:insert_at] + alt + mrna[insert_at:], insert_at
+
+        if is_deletion:
+            # Anchor at affected_start is unchanged; deleted bases span
+            # [affected_start + 1, affected_end).
+            first_changed = affected_start + 1
+            last_changed = affected_end - 1
+        else:
+            # SNV/MNV: replace [affected_start, affected_end) entirely.
+            first_changed = affected_start
+            last_changed = affected_end - 1
+
+        m_a = self.genomic_to_mrna(transcript_id, first_changed)
+        m_b = self.genomic_to_mrna(transcript_id, last_changed)
+        if m_a is None or m_b is None:
+            return None, None
+
+        lo, hi = min(m_a, m_b), max(m_a, m_b)
+        alt = '' if is_deletion else (revcomp(allele) if strand == '-' else allele)
+        return mrna[:lo] + alt + mrna[hi + 1:], lo
 
 class Counts:
     def __init__(self, countFile):

--- a/workflow/scripts/prioritization/variants.py
+++ b/workflow/scripts/prioritization/variants.py
@@ -71,27 +71,10 @@ class Variants():
                         if csq is None:
                             continue
                         elif csq == "frameshift":
-                            if field["NMD"] != 'NMD_escaping_variant':
-                                continue
-
-                            elif field["NMD"] == "NMD_escaping_variant":
-                                nmd = "NMD_escaping_variant"
-
-                                if transcript_id in annotation.transcriptome:
-                                    bnds = annotation.transcriptome[transcript_id]
-
-                                    # extract sequence until variant start
-                                    transcript = str(annotation.ref[chrom][bnds[0]+1:start+2])
-                                    if field["Allele"] != '-':
-                                        transcript += field["Allele"]
-                                    transcript += str(annotation.ref[chrom][stop+1:bnds[1]+1])
-
-                                    # extract sequence breakpoint (variant start)
-                                    transcript_bp = (start - bnds[0]) + 1
-
-
-                                # if transcript_id in transcriptome:
-                                    # transcript = transcriptome[transcript_id]
+                            if transcript_id in annotation.transcriptome:
+                                transcript, transcript_bp = annotation.splice_with_variant(
+                                    transcript_id, chrom, start, stop, field["Allele"]
+                                )
 
                             if field["DownstreamProtein"] == "":
                                 continue


### PR DESCRIPTION
## Summary
### Fixed
- Non-fusion variants walked pre-mRNA (genomic slice across introns), so `find_stop_codon` typically hit a spurious in-frame stop in the first intron downstream of the variant; `annotate_stop_codon` then dropped it as non-exonic and silently left NMD / `PTC_exon_number` / `PTC_dist_ejc` / `NMD_escape_rule` empty for SNV / short-indel / long-indel / exitron / alt-splicing rows.
- Built a strand-aware spliced-mRNA + genomic↔mRNA mapping layer on `Annotation` (`splice_transcript`, `exon_map`, `genomic_to_mrna`, `mrna_to_genomic`, `splice_with_variant`), rewrote `variants.py` to use it, adapted `find_stop_codon` / `annotate_stop_codon` / `check_escape` to operate on mRNA-relative coords with strand awareness (rules 2 and 3 in `check_escape` were `+`-strand-only as written), and removed the VEP `field["NMD"]` pre-filter so every frameshift reaches `determine_NMD`.
- Standardised both GTF parsers (`parse_transcriptome`, `parse_exome`) on 0-based half-open coordinates so exome / transcriptome / vcfpy / pyfaidx all share one convention; fusion path shifts the arriba 1-based seg2 breakpoint by -1 to compensate, preserving existing fusion behaviour.

Closes #116

## QC
- [ ] I, as a human being, have checked each line of code in this pull request
- [x] Re-run the `prioritization` rule via Snakemake on a real sample and confirm the downstream binding-affinity / similarity steps still complete end-to-end
- [x] `*_variant_effects.tsv` rows with `var_type` containing `frameshift` have `NMD` populated (`NMD_variant` or `NMD_escaping_variant`), where previously the column was empty for non-fusion sources
- [x] `NMD_escape_rule` distribution covers codes 1 / 3 / 4 across both `+` and `-` strand transcripts (rule 2 is rare in tumour data; absence is not a regression)
- [x] Spot-check ≥3 frameshifts per strand: the reported `PTC_exon_number` contains the genomic coord implied by `PTC_dist_ejc`, and that coord is downstream of the variant in transcript orientation
- [x] Fusion-path output is unchanged vs. main (compare `fusions_variant_effects.tsv` from a fusion-containing sample) — skipped: test sample had no fusion data; arithmetic change is the -1 shift on arriba seg2 breakpoint, mechanically small