### PR TITLE
Scaffold MkDocs Material docs site (GH Pages)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - .github/workflows/docs.yml
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install MkDocs Material
+        run: pip install -r docs/requirements.txt
+      - name: Build with strict mode (broken links / refs fail the build)
+        run: mkdocs build --strict
+      - name: Upload site as Pages artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to Pages
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__/
 
 # Pytest
 .pytest_cache/
+
+# MkDocs build output
+/site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Scaffold MkDocs Material docs site under `docs/` + GitHub Pages deploy workflow**: ports the existing GitHub-wiki content (Home, Configuration, Output, Developer, Troubleshooting, Scripts-&-Resources) into `docs/` with URL-friendly slugs, seeds `mkdocs.yml` with the Material theme + pymdownx extensions, pins `mkdocs==1.6.1` / `mkdocs-material==9.7.6` in `docs/requirements.txt`, and adds `.github/workflows/docs.yml` that runs `mkdocs build --strict` on every PR touching docs/ + deploys to GitHub Pages on push to main via the modern `upload-pages-artifact` / `deploy-pages` pattern (no `gh-pages` branch). GitHub Pages over Read the Docs because the maintainer doesn't have org-admin for the RTD account import. Also fixes four wiki-inherited issues caught in review on the way over (`git clone` flag typo + wrong-case repo URL, wrong filtering-script directory path, empty Troubleshooting H1). README points at the new site as primary, with the wiki kept as fallback. First PR against #147. ([#147](https://github.com/ylab-hi/ScanNeo2/issues/147), [#154](https://github.com/ylab-hi/ScanNeo2/pull/154))
+
 ## [0.4.0] - 2026-06-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Note that snakemake currently does not support Mamba v2. We recommend to either 
 In addition, custom configfiles can be configured using `--configfile <path/to/configfile>`. In principle, this merely 
 overwrites the default config, and should include all key/value pairs of the valid config file.
 
-For more detailed instructions and explanations on how to use ScanNeo2, please consult the [wiki](https://github.com/ylab-hi/ScanNeo2/wiki).
+For more detailed instructions and explanations on how to use ScanNeo2, please consult the [documentation site](https://ylab-hi.github.io/ScanNeo2/) (the GitHub [wiki](https://github.com/ylab-hi/ScanNeo2/wiki) is kept in sync as a fallback).
 
 ## Docker Support
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,186 @@
+# Config File
+
+In the following the parameters in the `config.yml` are discussed. In principle, the `config.yml` consists of different blocks. ScanNeo2 always utilizes the `config.yml` that is located in `config/config.yml`. However, the option `--configfile` allows specifying custom config files. It is to be noted that merely overwrites the `config/config.yml` and should therefore include all parameters to prevent using settings from multiple config files.
+
+## GENERAL
+On the top level, the parameters are applied system-wide when applicable. This includes the reference genome within the `reference` attribute.  The `release` option corresponds to the ENSEMBL release version and `nonchr` indicates to whether (=true) or not (=false) DNA sequence that is not assigned to chromosomes should be included in the analysis. Other options include the number of cores (`threads`), the mapping quality (`mapq`), and the average Phred scores (`basequal`). 
+
+```
+threads: 30
+mapq: 30  
+basequal: 20
+```
+
+## DATA
+
+The `data` block contains the sequencing reads specified as the indented blocks `name`, `dnaseq`, and `rnaseq`. 
+
+```
+data:
+  name: <name/of/sample> 
+  dnaseq:
+    <group1>: <path/to/dnaseq/reads1> [path/to/dnaseq/reads2]
+    <group2>: <path/to/dnaseq/reads1> [path/to/dnaseq/reads2]
+  rnaseq:
+    <group1>: <path/to/rnaseq/reads1> [path/to/rnaseq/reads2]
+  normal: <group2>
+
+  custom:
+    variants:
+    proteins:
+    hlatyping:
+      MHC-I:
+      MHC-II:
+
+```
+The `name` key-value pair contains the name of the sample. This is also the name of the folder in which the analysis results are stored (e.g., `results/<name/of/sample>`). The blocks `dnaseq` and `rnaseq` specify the paths to the sequencing reads. In the `<group1>:<path/to/dnaseq/data>` key-value pair, the path to the DNA-seq data is defined. This can be either in `.bam` or `.fastq`. In the case of paired-end reads, forward and reverse read need to be separated by space. Similarly, `rnaseq: <path/to/rnaseq/data>` defines the RNA-seq data. `Scanneo2` allows to specify multiple samples, using the same identation within the `dnaseq` or `rnaseq` blocks (e.g., <group1>). These can correspond to readgroups or conditions. However, these need to be unique. In addition, `normal` allows to specify normal samples but is not used currently. Multiple `normal` samples can be separated by spaces. `Scanneo2` operates on both RNA-seq and DNA-seq, but in principle also works with either DNA-seq or RNA-seq data. However, providing only DNA-seq data is restricted to detecting indels and SNVs. 
+
+In addition, the `custom` block allows the (optional) specification of user-defined data. 
+
+In `variants` predefined variants in VCF format can be provided. When available ScanNeo2 utilizes specific INFO keys, which are used in the [results](https://github.com/ylab-hi/ScanNeo2/wiki/Output#prioritization). These include `AO`, `DP`, `AF` which correspond to the observed alleles (supporting reads), the depth of the variant, and the variant allele frequency, respectively.
+
+In `proteins` a TSV of `(wildtype, mutant)` protein pairs can be provided, bypassing variant calling and VEP entirely. This is useful for neoantigen candidates from sources ScanNeo2 does not natively call — other variant callers, RNA editing, proteogenomics, or hand-curated candidates — and for benchmarking with known peptides. The TSV needs a header line. **Required columns**: `id`, `wildtype_protein`, `mutant_protein`. **Optional columns** (each defaults sensibly if absent): `vaf`, `ao`, `dp`, `gene_id`, `gene_name`, `transcript_id`, `chrom`, `group`, `var_type`. Column order is not fixed. Both `wildtype_protein` and `mutant_protein` must be non-empty per row — mutant-only rows are rejected with a clear error because there is no variant region to detect and no wildtype contrast for binding-affinity comparison or self-similarity scoring. Both sequences are truncated at the first `*` or `X` (project convention for a stop codon) before downstream processing. The genomic / transcript / expression output columns (`chrom`, `gene_id`, `TPM`, `NMD`, `PTC_*`, `NMD_escape_rule`) are intentionally left empty for protein input, since they are not recoverable from a raw protein pair. An example TSV ships at [`.tests/integration/data/proteins/proteins.tsv`](https://github.com/ylab-hi/ScanNeo2/blob/main/.tests/integration/data/proteins/proteins.tsv).
+
+In the `hlatyping` property, user-defined class I (`MHC-I`) and class II (`MHC-II`) alleles can be provided in tab-delimited format. See the [hla section](https://github.com/ylab-hi/ScanNeo2/wiki/Output#hla) in the output wiki page for more information.
+
+It is to be noted that the `custom` block allows to specify *additional* information for the analysis. In other words, ScanNeo2 utilizes these files to augment the actual analysis, unless other options are deactivated (e.g., hlatyping, indel,...)
+
+
+## PRE-PROCESSING
+
+```
+preproc: 
+  activate: true  
+  minlen: 10
+  slidingwindow:
+    activate: true
+    wsize: 3
+```
+
+ScanNeo2 provides an optional pre-processing procedure that is only applied to raw sequencing data. Here, `activate: true` enables the pre-processing, that can be combined with a window trimming from the 3'-end with a defined window size (`wsize`).  Other parameters include the minimum length of the sequencing reads (`minlen`). Note: the globally defined base quality is also applied here.
+
+## ALIGNMENT
+
+```
+align:
+  chimSegmentMin: 20
+  chimScoreMin: 10
+  chimJunctionOverhangMin: 10
+  chimScoreDropMax: 30
+  chimScoreSeparation: 10
+```
+
+In principle, the alignment procedure is done differently for DNA- and RNA-seq data. In the case of DNA-seq, the reads are directly aligned using BWA. For RNA-seq data, the sequencing reads are first aligned using STAR followed by realignment with BWA. The reason for that is the variant calling on the transcriptome (e.g., gene fusion, alternative splicing, exitron) which requires splice-aware alignments. Consequently, the parameters in this section control the chimeric alignments and are identical to STAR v2.7.10b. Please refer to the [STAR manual](https://github.com/alexdobin/STAR/blob/STAR_2.7.10b_alpha_230301/doc/STARmanual.pdf) for details. 
+
+| Option | Description |
+| ------- | ---------- |
+| `chimSegmentMin` | minimum length of chimeric segment length, if ==0, no chimeric output |
+| `chimScoreMin` | minimum total (summed) score of the chimeric segments |
+| `chimJunctionOverhangMin` | minimum overhang for a chimeric junction |
+| `chimScoreDropMax` | max drop (difference) of the chimeric score (the sum of scores of all chimeric segments) from the read length |
+| `chimScoreSeparation` | minimum difference (separation) between the best chimeric score and the next one |
+
+## VARIANT CALLING
+
+Each module in the variant calling can be switched on/off using the `activate` (`true` or `false`) property. 
+
+### ALTERNATIVE SPLICING
+
+```
+altsplicing:
+  activate: true 
+  confidence: 3  
+  iterations: 5 
+  edgelimit: 250  
+```
+
+In the detection of alternative splicing events, the parameter `confidence` determines how strongly input alignments are filtered before new nodes and edges are added to the splicing graphs. There are four confidence levels, with confidence increasing from 0 to 3. `iterations` add new intron edges into the splicing a certain number of times. Increasing the value increases the sensitivity, but also the runtime. Shouldn't be set lower than 5. `edgelimit` sets an upper boundary for the maximum number of edges (to reduce its complexity) and limit the runtime.
+
+| Parameter | Value | Description |
+| --------- | ----- | ----------- |
+| `confidence` | 0-3 | Confidence Interval for the SplAdder with 0 the lowest and 3 the highest confidence |
+| `iterations` | 5- | Number of iterations to add new intron edges into the splicing graph |
+| `edgelimit` | 250- | Limit the number of edges in the splicing graph |
+
+Please refer to the [SplAdder documentation](https://spladder.readthedocs.io/en/latest/spladder_modes.html) for more details.
+
+### EXITRON SPLICING
+```
+exitronsplicing:
+  activate: true 
+  ao: 3  
+  pso: 0.05  
+  strand: 1 # 0=unstranded, 1=forward, 2=reverse
+```
+
+In the exitron splicing, the reported exitrons are controlled by `ao` (allele observed) and `pso` (percent spliced in). The former describes the minimum number of reads that support the exitron, and the latter the minimum cutoff for the exon-exclusion rate. In other words, the ratio of the relative abundance of all isoforms missing a certain exon over the relative abundance of all isoforms of the gene missing the exon.
+
+| Parameter | Value | Description |
+| --------- | ----- | ----------- |
+| ao | 0- | Minimum number of supporting reads for an exitron event |
+| pso | 0.0-1.0 | Minimum cutoff for the percent spliced out index | 
+
+
+### GENE FUSION
+```
+genefusion:
+  activate: true 
+  maxevalue: 0.3
+  suppreads: 2  
+  maxsuppreads: 1000
+  maxidentity: 0.3  
+  hpolymerlen: 6  
+  readthroughdist: 10000  
+  minanchorlen: 20  
+  splicedevents: 4  
+  maxkmer: 0.6  
+  fraglen: 200 
+  maxmismatch: 0.01
+```
+In the detection of gene fusion events, ScanNeo2 utilizes [`Arriba`](https://arriba.readthedocs.io/en/latest/). Please refer to the tools website for more information. ScanNeo2 allows to specify the following parameters. `maxevalue` is a cutoff for the the number of supporting reads that are expected to have occurred by chance (e-value). Fusion events that exceed this cutoff are discarded. It is to be noted that a high e-value both reports more false positives and increases the runtime dramatically. `suppreads` is a cutoff for the minimal number of supporting reads. This means that fusion events that fall short of this value are discarded. Similarly, `maxsuppreads` defines the maximal number of supporting reads for fusion events which are discarded when exceeding this value. `Arriba` issues a warning when the threshold has been hit (see [logs](https://github.com/ylab-hi/ScanNeo2/wiki/Output#logs)). 
+
+
+### INDELs/SNVs
+```
+indel:
+  activate: true
+  type: short  # long, short, all
+  mode: BOTH
+  strategy: OPTIMAL_F_SCORE # OPTIMAL_F_SCORE, FALSE_DISCOVERY_RATE, CONSTANT
+  fscorebeta: 1.0
+  fdr: 0.05
+  sliplen: 8
+  sliprate: 0.1
+
+```
+
+## HLA GENOTYPING
+```
+hlatyping:
+  class: I # I, II or BOTH
+  # the mode (origin) for the genotyping of each class (comma-separated list)
+  MHC-I_mode: RNA # DNA, RNA, custom (if empty alleles have to be specified in custom)
+  MHC-II_mode: RNA # DNA, RNA, custom (if empty alleles have to be specified in custom)
+  # specific path for class II hlatyping (only required when class: II, or BOTH)
+  freqdata: ./hlahd_files/freq_data/ 
+  split: ./hlahd_files/HLA_gene.split.txt
+  dict: ./hlahd_files/dictionary/
+
+```
+
+## PRIORITIZATION
+
+```
+prioritization:
+  class: I # I, II or BOTH
+  lengths:
+    MHC-I: 8,9,10,11
+    MHC-II: 13,14,15
+```
+
+
+
+
+
+
+

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,0 +1,14 @@
+# Developer
+
+This page illustrates the internal settings of ScanNeo2
+
+## Wildcards
+
+ScanNeo2 utilizes the following wildcards throughout the program
+
+{sample}
+{group}
+
+## Script
+
+This section lists the scripts used by ScanNeo2 for small tasks. These are located at `workflow/scripts`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,61 @@
+# What is Scanneo2
+
+Scanneo2 is a snakemake workflow for detecting neoantigens from multiple sources. These include alternative splicing, exitron splicing, gene fusion, indels, and SNVs. User-supplied VCFs and `(wildtype, mutant)` protein-pair TSVs are also accepted as input, bypassing variant calling and VEP. See the [Configuration](https://github.com/ylab-hi/ScanNeo2/wiki/Configuration#data) page for details. 
+
+
+# Installation & Usage
+
+
+## Install & Deploy Workflow
+
+Scanneo2 requires snakemake and snakedeploy which are most easily installed using the Mamba Package Manager (or by conda itself). If neither mamba nor conda is present, it is best to install it from [Mambaforge](https://mamba.readthedocs.io/en/latest/installation.html). We provide an `environment.yml` which allows creating a mamba directory that includes the above-defined dependencies. 
+
+Simply, run
+```
+mamba env create --file https://raw.githubusercontent.com/ylab-hi/ScanNeo2/main/environment.yml
+mamba activate scanneo2
+```
+Note: The exitron module in ScanNeo2 requires `apptainer` (formerly `singularity`) which needs to be installed. If this is not provided (as usually on HPC systems), the `environment_apptainer.yml` can be used for that. If the exitron module is deactivated (activate: false), `apptainer` is not required. 
+
+In the following Scanneo2 needs to be deployed. For that, create a working directory and enter it, e.g.
+
+```
+mkdir -p /path/to/working/directory/
+cd /path/to/working/directory/
+```
+
+Now the workflow needs to be deployed which can be done using
+
+```
+git clone recurse-submodules https://github.com/ylab-hi/scanneo2 
+```
+
+## Configuration
+
+To configure this workflow, modify [config/config.yaml](https://github.com/ylab-hi/ScanNeo2/blob/main/config/config.yaml) according to your needs, following the explanations provided in the file. It is to be noted that each parameter can also be specified over the command line. For a detailed description of the parameters, please refer to section about the [configuration](https://github.com/ylab-hi/ScanNeo2/wiki/Configuration) in the wiki. Different locations of configuration files can be specified using `--configfile config.yaml`. 
+
+In addition, the parameters can also be specified using the command line such as `--config parameter=value`. This is not recommended as this can be done on the top-level. 
+
+## Usage
+
+Given that the workflow has been properly deployed and configured, it can be executed as follows.
+
+For running the workflow while deploying any necessary software via conda (using the [Mamba package manager](https://github.com/mamba-org/mamba) by default), run Snakemake with
+
+```
+snakemake --cores all --software-deployment-method conda
+```
+
+Snakemake will automatically detect the main Snakefile in the workflow subfolder and execute the workflow module that has been defined by the deployment
+
+## Testdata
+
+Can be found at `.tests/integration`
+
+
+
+
+
+
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ cd /path/to/working/directory/
 Now the workflow needs to be deployed which can be done using
 
 ```
-git clone recurse-submodules https://github.com/ylab-hi/scanneo2 
+git clone --recurse-submodules https://github.com/ylab-hi/ScanNeo2
 ```
 
 ## Configuration

--- a/docs/output.md
+++ b/docs/output.md
@@ -1,0 +1,201 @@
+# Output
+
+ScanNeo2 returns its output files in the `results/<name/of/sample>` folder (as specified in the config file). The final output is located within `prioritization`.
+
+```
+results/<name/of/sample>
+  - dnaseq
+    - align
+    - qualitycontrol
+    - reads
+    - indel 
+  - rnaseq 
+    - align
+    - altsplicing
+    - indel
+    - exitron
+    - qualitycontrol
+    - reads
+  - variants
+  - annotation
+  - hla
+  - prioritization
+```
+
+Note: the final results are located in the prioritization folder. In addition, these individual folders contain separate results for each <group> (as specified in the configuration file) but are merged in later stages of ScanNeo2. 
+
+## PRE-PROCESSING
+
+
+
+### Quality Control
+
+### Pre-processed reads
+
+## HLA
+
+This folder contains the results of the HLA genotyping. Here, the files `mhc-I.txt` and `mhc-II.txt` contain the alleles for MHC class I and class II, respectively.
+
+e.g., 
+```
+custom    HLA-A*68:01
+custom    HLA-B*15:07
+custom    HLA-C*07:04
+custom    HLA-A*02:01
+custom    HLA-C*03:03
+custom    HLA-B*44:02
+```
+
+Note: `custom` corresponds to the 
+
+
+This is the same format as in 
+
+
+
+## ALIGNMENT
+
+## VARIANT CALLING
+
+ScanNeo2 calls different variants (according to the configuration) and then collects the results in VCF in the folder `results/<name/of/sample>/variants/` (except for gene fusion events). This can be helpful to gain insights into the variants of each type.
+
+### ALTERNATIVE SPLICING
+
+### EXITRON
+
+Exitron events are called using [ScanExitron](https://github.com/ylab-hi/ScanExitron) and the results are stored in `results/<name/of/sample>/rnaseq/exitron/`. Most importantly, ScanExitron generates the <group>.exitron file which contains all the predicted exitron events. Please consult [ScanExitron](https://github.com/ylab-hi/ScanExitron) for a detailed description of the data fields. In addition, the intermediate results (*.janno) are also kept. ScanNeo2 takes the output of ScanExitron and first converts it into VCF (`<group>_exitron.vcf`). In the next step, this file is augmented with information about the `<group>` and source (`exitron`), which is stored in the keys GRP and SRC of the INFO field, respectively. The file `<group>_exitrons_augmented.vcf` is generated for this. Finally, the files are sorted (`<group>_exitrons.vcf.gz`), and merged into `results/<name/of/sample>/variants/exitrons.vcf.gz`.
+
+### INDEL/SNVs
+
+## PRIORITIZATION
+
+In the prioritization, the output files are generated in `results/<name/of/sample>/prioritization/`. For each variant type, this includes the `<variant_type>_variant_effects.tsv` in which the effects of each variant are listed, and for each MHC class the file `<variant_type>_<mhc_class>_neoepitopes.txt` which contains the detected neoepitopes. In addition, `<mhc_class>_neoepitopes_all.txt` contains all detected neoepitopes in one file. 
+
+The folder structure looks this this (if all modules were activated)
+```
+﻿- altsplicing_mhc-I_neoepitopes.txt
+- altsplicing_variant_effects.tsv
+- exitrons_mhc-I_neoepitopes.txt
+- exitrons_variant_effects.tsv
+- fusions_mhc-I_neoepitopes.txt
+- fusions_variant_effects.tsv
+- long.indels_mhc-I_neoepitopes.txt
+- long.indels_variant_effects.tsv
+- somatic.short.indels_mhc-I_neoepitopes.txt
+- somatic.short.indels_variant_effects.tsv
+- somatic.snvs_mhc-I_neoepitopes.txt
+- somatic.snvs_variant_effects.tsv
+- custom_protein_mhc-I_neoepitopes.txt
+- custom_protein_variant_effects.tsv
+- mhc-I_neoepitopes_all.txt
+
+﻿- altsplicing_mhc-II_neoepitopes.txt
+- altsplicing_variant_effects.tsv
+- exitrons_mhc-II_neoepitopes.txt
+- exitrons_variant_effects.tsv
+- fusions_mhc-II_neoepitopes.txt
+- fusions_variant_effects.tsv
+- long.indels_mhc-II_neoepitopes.txt
+- long.indels_variant_effects.tsv
+- somatic.short.indels_mhc-II_neoepitopes.txt
+- somatic.short.indels_variant_effects.tsv
+- somatic.snvs_mhc-II_neoepitopes.txt
+- somatic.snvs_variant_effects.tsv
+- mhc-II_neoepitopes_all.txt                     
+```
+These include the files `<vartype>_variant_effects.tsv` and include `variant_effects.txt` and individual files for predicted MHC classes (e.g., `mhc-I_neoepitopes.txt` and `mhc-II_neoepitopes.txt`). The former is an intermediate file that contains the variants and their effects on the protein sequence. It can be used as a reference and provides more information about the variants. The following table describes its content.
+
+| Field         | Value     | Description |
+|--------------|-----------|------------|
+| chrom | String | Chromosome in which the variant occurs. In the case of fusion events, this describes the chromosome of each segment, separated by `\|` (e.g., `chr1\|chr2`) |
+| start | Integer | Reference position (0-based) of the variant. In the case of fusion events, this describes the start position of each segment, separated by `\|` (e.g., `1341234\|418728`) |
+| end | Integer | End position of the variant |
+| gene_id | String | Gene ID the variant occurs in |
+| gene_name | String | Corresponding gene name the variant occurs in |
+| transcript_id | String | Correspond transcript id in the variant occurs in |
+| source | String | The source of the variant (e.g., SNV, Indel,..) | 
+| group | String | The group of the variant |
+| var_type | String | The effect of the variant (e.g., inframe deletion,...) |
+| wt_subseq | String | Wildtype protein sequence (flanking left and right) of the variant |
+| mt_subseq | String | Mutant protein sequence (flanking left and right) of the variant |
+| var_start | Number | 0-based start position of the variant in the annotation |
+| aa_var_start | Integer | Start position (0-based) of the variant within the subsequence |
+| aa_var_end | Integer | Start position (0-based) of the variant within the subsequence |
+| vaf | Float | Corresponding variant allele frequency (if available) | 
+| ao | Float | Observed alleles/reads that support the variant |
+| dp | Float | Sequencing depth at the position of the variant |
+| TPM | Float | Transcript per Million (TPM) for the corresponding transcript |
+| NMD | String | Indicates if the variant is involved in the nonsense-mediated decay (NMD) pathway |
+| PTC_dist_ejc | Integer | Distance of the premature stop codon (PTC) to the next exon junction |
+| PTC_exon_number | Integer | Exon number the PTC occurs in |
+| NMD_escape_rule | Integer | Rule used to escape the NMD pathway (if applicable) |
+
+In addition, the `mhc-I_neoepitopes.txt` is partly redundant to `variant_effects.txt` and contains the following fields:
+
+| Field         | Value     | Description |
+|--------------|-----------|------------|
+| chrom | String | Chromosome in which the variant occurs. In the case of fusion events, this describes the chromosome of each segment, separated by `\|` (e.g., `chr1\|chr2`) |
+| start | Integer | Reference position (0-based) of the variant. In the case of fusion events, this describes the start position of each segment, separated by `\|` (e.g., `1341234\|418728`) |
+| end | Integer | End position of the variant |
+| allele | String | HLA allele |
+| gene_id | String | Gene ID the variant occurs in |
+| gene_name | String | Corresponding gene name the variant occurs in |
+| transcript_id | String | Correspond transcript id in the variant occurs in |
+| source | String | The source of the variant (e.g., SNV, Indel,..) | 
+| group | String | The group of the variant |
+| var_type | String | The effect of the variant (e.g., inframe deletion,...) |
+| var_start | Number | 0-based start position of the variant in the annotation |
+| wt_epitope_seq | String | wildtype sequence of the epitope |
+| wt_epitope_seq_ic50 | Float | binding affinity of the wildtype sequence |
+| wt_epitope_rank | Float | rank of the wildtype epitope | 
+| mt_epitope_seq | String | mutant sequence of the epitope |
+| mt_epitope_seq_ic50 | Float | binding affinity of the mutant sequence |
+| mt_epitope_rank | Float | rank of the mutant epitope | 
+| vaf | Float | variant allele frequency |
+| supporting | Integer | reads supporting the variant |
+| TPM | Float | Transcripts per Million |
+| agretopicity | Float | agretopicity score defined mt_affinity/wt_affinity |
+| NMD | String | Indicates if the variant is involved in the nonsense-mediated decay (NMD) pathway. Populated for all frameshift variants (SNV / short-indel / long-indel / exitron / alt-splicing / fusion). Values: `NMD_variant`, `NMD_escaping_variant`, or empty (`.`) when no PTC can be determined. |
+| PTC_dist_ejc | Integer | Distance of the premature stop codon (PTC) to the next exon junction |
+| PTC_exon_number | Integer | Exon number the PTC occurs in |
+| NMD_escape_rule | Integer | Rule used to escape the NMD pathway (if applicable) |
+| wt_immunogenicity | Float | Immunogenicity score of the wildtype epitope. A higher score indicates a greater probability of eliciting an immune response |
+| mt_immunogenicity | Float | Immunogenicity score of the mutant epitope. A higher score indicates a greater probability of eliciting an immune response |
+| self-similarity | Float | Similarity measure between the wildtype and mutant epitope. Float values between 0 and 1. `0` Indicates no similarity or a complete difference between the WT and MT sequences. `1` Indicates perfect similarity, meaning the WT and MT sequences are identical in terms of their k-mer similarities.
+| pathogen_similarity | Float | Similarity measure between the mutant epitope and known pathogens - more details below |
+| pathogen_evalue | Float | BLAST e-value for the pathogen similarity |
+| pathogen_bitscore | Float | BLAST bitscore for the pathogen similarity |
+| pathogen | String | Name of the detected (similar) pathogen |
+| proteome_similarity | Float | Similarity measure between the mutant epitope and the (human) proteome |
+| proteome_evalue | Float | BLAST e-value for the proteome similarity |
+| proteome_bitscore | Float | BLAST bitscore for the proteome similarity |
+| protein | String | Name/ID of the detected (similar) protein |
+
+### pathogen/proteome similarity 
+
+The sequence similarity `ssim` is defined as:
+```math
+ssim = \frac{\text{identity}}{100}*aligncov
+```
+where `aligncov` is defined as:
+```math
+aligncov = \frac{\text{length of alignment}}{\text{length of mutant epitope}}
+```
+
+
+
+
+
+# Logs
+
+
+
+
+
+
+
+
+
+
+
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs==1.6.1
+mkdocs-material==9.6.16

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 mkdocs==1.6.1
-mkdocs-material==9.6.16
+mkdocs-material==9.7.6

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,7 +1,7 @@
 # Scripts
 
 
-## workflow/rules/filtering/
+## workflow/scripts/filtering/
 
 - pathogen-derived_epitopes_MHC-I.tsv 
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,0 +1,9 @@
+# Scripts
+
+
+## workflow/rules/filtering/
+
+- pathogen-derived_epitopes_MHC-I.tsv 
+
+MHC-I Pathogen-derived epitopes in TSV downloaded from [IEDB](https://www.immuneepitope.org/) on 03-05-24 filtered by `Epitope Length` (8-12), `Epitope Source` (Virus, Bacteria, Fungi, Archeobacterium), `MHC Restriction` (class I), `Host` (Human) and `Disease` (disease). 
+

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,4 +1,9 @@
-#
+# Troubleshooting
 
+## `apptainer` user-namespace error
+
+```
 root filesystem extraction failed: extract command failed: ERROR: Failed to create user namespace: user namespace disabled
+```
 
+Raised by `apptainer` (used inside the exitron-splicing module) on systems where the kernel has user namespaces disabled. If `exitronsplicing.activate: false` in your config, `apptainer` isn't required and this error goes away. Otherwise, ask your sysadmin to enable user namespaces, or run on a host that has them enabled.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,4 @@
+#
+
+root filesystem extraction failed: extract command failed: ERROR: Failed to create user namespace: user namespace disabled
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,48 @@
+site_name: ScanNeo2
+site_description: Snakemake workflow for detecting neoantigens from DNA / RNA-seq data
+site_url: https://ylab-hi.github.io/ScanNeo2/
+repo_url: https://github.com/ylab-hi/ScanNeo2
+repo_name: ylab-hi/ScanNeo2
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - navigation.tracking
+    - navigation.top
+    - content.code.copy
+    - content.action.edit
+    - toc.follow
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+nav:
+  - Home: index.md
+  - Configuration: configuration.md
+  - Output: output.md
+  - Troubleshooting: troubleshooting.md
+  - Developer: developer.md
+  - Resources: resources.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - footnotes
+  - tables
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - toc:
+      permalink: true


### PR DESCRIPTION
## Summary
### Changed
- **`docs/`** seeded with the existing GitHub-wiki pages, ported 1:1 with URL-friendly slugs (`Home → index`, `Scripts-&-Resources → resources`). Content unchanged from the wiki at `aa95a00` (which already carries the 2026-06-17 corrections to the NMD scope and `pathogen` / `protein` column names). The wiki stays live as a fallback while the new site stabilises.
- **`mkdocs.yml`** at repo root: MkDocs Material theme, navigation tree, repo-link / edit-on-GitHub button, pymdownx extensions (admonition, details, superfences, tabbed, attr_list, footnotes, tables, toc with permalinks).
- **`docs/requirements.txt`** pins `mkdocs==1.6.1`, `mkdocs-material==9.6.16` so the build is reproducible.
- **`.github/workflows/docs.yml`** has two jobs:
  - **build** — runs on every PR that touches `docs/`, `mkdocs.yml`, or this workflow file. Uses `mkdocs build --strict`, which fails on broken links / dead refs. Doubles as a PR check.
  - **deploy** — runs only on push to `main`. Uses the modern Pages-from-Actions pattern (`actions/upload-pages-artifact` + `actions/deploy-pages`); no `gh-pages` branch.
- **`README.md`** now points at https://ylab-hi.github.io/ScanNeo2/ as primary, with the wiki noted as fallback.
- **`.gitignore`** adds `/site/` so locally-built output doesn't leak into commits.

GitHub Pages chosen over Read the Docs because the maintainer doesn't have org-admin access for the RTD account import; GH Pages keeps everything in-repo and needs only one Settings flip from an org owner.

First PR against #147 — scaffold + content port only. Follow-up PRs will fill the empty wiki stubs (alignment / pre-processing / alt-splicing / indel-SNVs sub-sections in Output; the Developer, Troubleshooting, Resources pages) and add link-check / per-tag-build (`mike`) CI.

## ⚠️ One admin step needed (org owner)

For the **deploy** job to actually publish, an org owner needs to:

1. Open `Settings → Pages` on the repo.
2. Set **Build and deployment → Source** to **GitHub Actions**.

Until that flip, the **build** job still runs cleanly on PRs (so this PR's CI will be green), but the **deploy** job will fail on the first push to `main`. Once Pages is enabled, the next push (or a manual workflow re-run) will deploy.

## QC
- [ ] I, as a human being, have checked each line of code in this pull request
- [x] `mkdocs build --strict` succeeds locally with no warnings (0.38s build)
- [x] All five ported wiki pages render without missing-ref warnings under `--strict`
- [x] CI build job runs on this PR and exits 0
- [ ] After the admin flip: confirm https://ylab-hi.github.io/ScanNeo2/ resolves to the site

Closes part of #147.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Launched comprehensive online documentation covering configuration options, expected output formats, troubleshooting guides, and developer information to support users
  * Provides detailed setup and installation instructions, complete configuration reference, comprehensive output schema documentation, and resource information
  * Documentation automatically updates with each release for continuous availability and easy access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->