### PR TITLE
Fix fusion dp: numeric sum of arriba coverage columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Scaffold MkDocs Material docs site under `docs/` + GitHub Pages deploy workflow**: ports the existing GitHub-wiki content (Home, Configuration, Output, Developer, Troubleshooting, Scripts-&-Resources) into `docs/` with URL-friendly slugs, seeds `mkdocs.yml` with the Material theme + pymdownx extensions, pins `mkdocs==1.6.1` / `mkdocs-material==9.7.6` in `docs/requirements.txt`, and adds `.github/workflows/docs.yml` that runs `mkdocs build --strict` on every PR touching docs/ + deploys to GitHub Pages on push to main via the modern `upload-pages-artifact` / `deploy-pages` pattern (no `gh-pages` branch). GitHub Pages over Read the Docs because the maintainer doesn't have org-admin for the RTD account import. Also fixes four wiki-inherited issues caught in review on the way over (`git clone` flag typo + wrong-case repo URL, wrong filtering-script directory path, empty Troubleshooting H1). README points at the new site as primary, with the wiki kept as fallback. First PR against #147. ([#147](https://github.com/ylab-hi/ScanNeo2/issues/147), [#154](https://github.com/ylab-hi/ScanNeo2/pull/154))
 
+### Fixed
+
+- **Fusion `dp` was a string concatenation, not a numeric sum**: `workflow/scripts/prioritization/fusions.py:62` computed `dp` as `str(cols[12] + cols[13])`, where the two operands are arriba's `coverage1` / `coverage2` string columns. Concatenation produced six-digit `dp` values like `'4560'` (from `'45'` + `'60'`) in `fusions_variant_effects.tsv` instead of the real total `105`. Fixed to `str(int(cols[12]) + int(cols[13]))`. Pre-existing bug carried through the #92 indentation change; the fix is a one-line surgical edit untouched by surrounding structure. ([#96](https://github.com/ylab-hi/ScanNeo2/issues/96), [#157](https://github.com/ylab-hi/ScanNeo2/pull/157))
+
 ## [0.4.0] - 2026-06-17
 
 ### Changed

--- a/workflow/scripts/prioritization/fusions.py
+++ b/workflow/scripts/prioritization/fusions.py
@@ -59,7 +59,7 @@ class Fusions:
                         transcript_id = tid1 + '|' + tid2
 
                         ao = str(len(cols[29]))
-                        dp = str(cols[12]+cols[13])
+                        dp = str(int(cols[12]) + int(cols[13]))
 
                         # get the fusion transcript
                         transcript = cols[27].upper()


### PR DESCRIPTION
## Summary
### Fixed
- `workflow/scripts/prioritization/fusions.py:62`: `dp = str(cols[12]+cols[13])` was string-concatenating the two arriba coverage columns (`coverage1`, `coverage2`) instead of summing them numerically. `'45' + '60'` produced a six-digit `dp` value of `'4560'` written to `fusions_variant_effects.tsv` instead of the real total `105`. Fixed to `str(int(cols[12]) + int(cols[13]))`. Matches the numeric intent of the `dp` ("read depth") field and the way every other source populates it.

Closes #96.

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] One-line edit; surrounding `with effects.VariantEffects(...)` context-manager structure from #92 untouched
- [ ] On the next fusion-containing run, the `dp` column in `fusions_variant_effects.tsv` is a sum on the order of single/double-digit thousands rather than a six-digit concatenated string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed variant effect computation to calculate numeric totals correctly instead of string concatenation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->