### PR TITLE
Gate IEDB prediction-tool downloads on prioritization.class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **MHC-II prediction tools no longer downloaded on class-I-only runs**: `rule prioritization` declared the IEDB tool directories (`workflow/scripts/{mhc_i,mhc_ii,immunogenicity}/`) as unconditional inputs, so `download_mhcII_ba_tools` was pulled into the DAG even when `prioritization.class: I` — a needless large IEDB MHC-II download the run never uses (`compile.py` gates binding on `mhc_class`, and immunogenicity is MHC-I only). Gated the tool-dir inputs on `prioritization.class` via new `get_mhcI_ba_tools` / `get_mhcI_immunogenicity_tools` / `get_mhcII_ba_tools` (MHC-I + immunogenicity for `{I, BOTH}`, MHC-II for `{II, BOTH}`); nothing downstream changes since `compile.py` already no-ops the unused class. Verified by dry-run with the tool dir hidden: a class-I run no longer schedules the MHC-II download, a `BOTH` run still does. ([#160](https://github.com/ylab-hi/ScanNeo2/issues/160), [#163](https://github.com/ylab-hi/ScanNeo2/pull/163))
+
 ## [0.5.0] - 2026-09-09
 
 ### Added

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1513,6 +1513,28 @@ def get_prioritization_mhcII(wildcards):
     return alleles
 
 
+# IEDB prediction tool directories are required by rule prioritization only for
+# the class it actually predicts (compile.py runs MHC-I / MHC-II binding gated on
+# prioritization.class; immunogenicity is MHC-I only). Gating the inputs keeps a
+# class-I run from pulling the MHC-II download rule (and vice versa).
+def get_mhcI_ba_tools(wildcards):
+    if config["prioritization"]["class"] in ["I", "BOTH"]:
+        return ["workflow/scripts/mhc_i/"]
+    return []
+
+
+def get_mhcI_immunogenicity_tools(wildcards):
+    if config["prioritization"]["class"] in ["I", "BOTH"]:
+        return ["workflow/scripts/immunogenicity/"]
+    return []
+
+
+def get_mhcII_ba_tools(wildcards):
+    if config["prioritization"]["class"] in ["II", "BOTH"]:
+        return ["workflow/scripts/mhc_ii/"]
+    return []
+
+
 def get_prioritization_counts(wildcards):
     counts = []
     # counts can only be generated if either RNAseq or DNAseq data is provided

--- a/workflow/rules/prioritization.smk
+++ b/workflow/rules/prioritization.smk
@@ -72,9 +72,9 @@ rule prioritization:
         peptide="resources/refs/peptide.fasta",
         annotation="resources/refs/genome_tmp.gtf",
         counts=get_prioritization_counts,
-        mhcI_ba="workflow/scripts/mhc_i/",
-        mhcII_ba="workflow/scripts/mhc_ii/",
-        mhcI_im="workflow/scripts/immunogenicity/",
+        mhcI_ba=get_mhcI_ba_tools,
+        mhcII_ba=get_mhcII_ba_tools,
+        mhcI_im=get_mhcI_immunogenicity_tools,
     output:
         directory("results/{sample}/prioritization/"),
     log:


### PR DESCRIPTION
## Summary

### Fixed
Fixes #160. `rule prioritization` declared the IEDB prediction-tool directories as **unconditional** inputs:

```python
mhcI_ba="workflow/scripts/mhc_i/",
mhcII_ba="workflow/scripts/mhc_ii/",
mhcI_im="workflow/scripts/immunogenicity/",
```

so `download_mhcII_ba_tools` was pulled into the DAG on **every** run — including `prioritization.class: I`, which never does MHC-II binding (`compile.py` gates binding on `mhc_class`, and `filtering.Immunogenicity` is MHC-I only / commented out for MHC-II). Result: a needless large IEDB MHC-II download for class-I runs.

**Fix**: gate the tool-dir inputs on `prioritization.class`, mirroring the existing `get_prioritization_mhcI/mhcII` allele-input gating — new `get_mhcI_ba_tools` / `get_mhcI_immunogenicity_tools` (`{I, BOTH}`) and `get_mhcII_ba_tools` (`{II, BOTH}`). The rule's shell never references these inputs (`prediction.py` uses fixed paths), so they are pure download-ordering deps and gating is safe; `compile.py` already no-ops the unused class.

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] `snakefmt --check` clean on the two changed `.smk` files
- [x] class-I dry-run (`mhc_ii/` hidden) no longer schedules `download_mhcII_ba_tools` (0)
- [x] class-`BOTH` dry-run (`mhc_ii/` hidden) still schedules it (≥1)
- [x] `replicate-test` dry-run still builds cleanly

Scoped out of #159; independent, workflow-wide fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - MHC-I-only runs no longer download MHC-II prediction tools.
  - MHC-II-only runs no longer download MHC-I prediction or immunogenicity tools.
  - Tool downloads are now limited to those required by the selected prioritization class.
  - Runs configured for both MHC classes continue to download the applicable tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->