### PR TITLE
Bump ScanNeo2 to Snakemake 9

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -41,6 +41,7 @@ jobs:
           persist-credentials: false
       - uses: snakemake/snakemake-github-action@v1
         with:
+          snakemake-version: '9.24.0'
           directory: '.tests'
           snakefile: 'workflow/Snakefile'
           args: '--lint --configfile .tests/integration/config_basic/config.yaml'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Bump to Snakemake 9**: `environment.yml` now installs `snakemake>=9,<10` (was `snakemake=8.4.11`) from the `conda-forge` / `bioconda` channels — the `anaconda` channel was dropped (it emitted Terms-of-Service warnings and blocked the solve) — and `min_version` is raised to `9.0.0`. The workflow lints and dry-runs cleanly on Snakemake 9 with the pandas-based sample-sheet loader; no rule / wrapper / checkpoint changes were required. CI linting pins `snakemake-version: 9.24.0` so it runs against Snakemake 9. ([#161](https://github.com/ylab-hi/ScanNeo2/issues/161), [#164](https://github.com/ylab-hi/ScanNeo2/pull/164))
+
 ### Fixed
 
 - **MHC-II prediction tools no longer downloaded on class-I-only runs**: `rule prioritization` declared the IEDB tool directories (`workflow/scripts/{mhc_i,mhc_ii,immunogenicity}/`) as unconditional inputs, so `download_mhcII_ba_tools` was pulled into the DAG even when `prioritization.class: I` — a needless large IEDB MHC-II download the run never uses (`compile.py` gates binding on `mhc_class`, and immunogenicity is MHC-I only). Gated the tool-dir inputs on `prioritization.class` via new `get_mhcI_ba_tools` / `get_mhcI_immunogenicity_tools` / `get_mhcII_ba_tools` (MHC-I + immunogenicity for `{I, BOTH}`, MHC-II for `{II, BOTH}`); nothing downstream changes since `compile.py` already no-ops the unused class. Verified by dry-run with the tool dir hidden: a class-I run no longer schedules the MHC-II download, a `BOTH` run still does. ([#160](https://github.com/ylab-hi/ScanNeo2/issues/160), [#163](https://github.com/ylab-hi/ScanNeo2/pull/163))

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <h1>ScanNeo2</h1>
     <img src="https://img.shields.io/github/v/release/ylab-hi/ScanNeo2">
     <img src="https://github.com/ylab-hi/ScanNeo2/actions/workflows/linting.yml/badge.svg" alt="Workflow status badge">
-    <img src="https://img.shields.io/badge/snakemake-≥8.0.0-brightgreen.svg">
+    <img src="https://img.shields.io/badge/snakemake-≥9.0.0-brightgreen.svg">
     <img src="https://img.shields.io/badge/License-MIT-yellow.svg">
     <img alt="Citation Badge" src="https://api.juleskreuer.eu/citation-badge.php?doi=10.1093/bioinformatics/btad659">
     <img src="https://img.shields.io/github/downloads/ylab-hi/ScanNeo2/total.svg">
@@ -39,7 +39,7 @@ To get started with ScanNeo2, follow the steps below:
     mamba activate scanneo2
     ```
 
-    Note: ScanNeo2 requires Snakemake >= 8.0 and is not compatible with earlier versions.
+    Note: ScanNeo2 requires Snakemake >= 9.0 and is not compatible with earlier versions.
 
 2. Deploy ScanNeo2:
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,7 @@
 name: scanneo2
 channels:
- - bioconda
  - conda-forge
- - anaconda
+ - bioconda
 dependencies:
- - snakemake=8.4.11
+ - snakemake>=9,<10
  - snakemake-wrapper-utils

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -2,7 +2,7 @@ from snakemake.utils import min_version, validate
 import pandas as pd
 
 ##### set minimum snakemake version #####
-min_version("8.0.0")
+min_version("9.0.0")
 
 
 #### setup #######


### PR DESCRIPTION
## Summary

### Changed
Bumps ScanNeo2 from Snakemake 8 to Snakemake 9 (prerequisite for the SLURM executor profile in #161, whose current plugin requires the Snakemake 9 executor interface).

- **`environment.yml`**: `snakemake=8.4.11` → `snakemake>=9,<10`, on `conda-forge` / `bioconda`. Dropped the `anaconda` channel — it emitted Terms-of-Service warnings and blocked the solve. `pandas` (used by the sample-sheet loader) still arrives transitively with Snakemake, so no explicit pin is needed.
- **`workflow/Snakefile`**: `min_version("8.0.0")` → `min_version("9.0.0")`.
- **`README.md`**: badge and note updated to Snakemake ≥ 9.0.
- **`.github/workflows/linting.yml`**: pin `snakemake-version: 9.24.0` on the lint action so CI runs against Snakemake 9 (matching the new `min_version`).

No rule / wrapper / checkpoint changes were required — the workflow is compatible with Snakemake 9 as-is (the one 9.0.0 breaking change, the logging refactor, doesn't affect ScanNeo2, which uses no logging plugins).

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] `environment.yml` solves (Snakemake 9.26.1, snakemake-wrapper-utils 0.9.0, pandas 2.3.3 transitive)
- [x] `snakemake --lint` clean on a Snakemake 9 env (9.24.0) against `config_basic`
- [x] `snakemake -n` dry-run clean on Snakemake 9 (replicate config): per-group fan-out + per-sample pooling intact
- [x] CI lint pinned to Snakemake 9 so it exercises the new floor

Follow-up: the SLURM executor profile (#161) lands on top of this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the supported Snakemake version to 9.x.
  - Installation requirements now require Snakemake 9.0 or later and exclude earlier versions.

- **Documentation**
  - Added unreleased changelog notes covering the Snakemake upgrade and updated environment requirements.

- **Bug Fixes**
  - Improved environment setup compatibility by refining package channel configuration and allowing supported Snakemake 9 releases.

- **Chores**
  - CI validation now uses Snakemake 9.24.0 for consistent workflow checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->