### PR TITLE
Fix wildcard ambiguities, HLA-typing DAG, and SLURM resources for at-scale runs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -232,6 +232,8 @@ snakemake --workflow-profile workflow/profiles/slurm --configfile config/config.
 
 Snakemake then submits each job with `sbatch`, translating each rule's `threads` into `--cpus-per-task` and the per-rule `runtime` / `mem_mb` from the profile into walltime / memory. With a sample sheet that has multiple samples or replicate groups, the independent per-group branches (alignment, variant calling) fan out across nodes; the per-sample prioritization stays a single job.
 
+> **Node memory requirement:** the largest single job is `arriba` (gene fusion) at **128 GB** on deep-RNA samples, so the target partition must have nodes with **≥128 GB RAM**. Other memory-heavy steps are STAR alignment and OptiType HLA typing at 64 GB, and several GATK/VQSR steps at 32–64 GB.
+
 The profile is deliberately **cluster-agnostic**: it sets no account and no partition, so jobs land on your cluster's default partition under your default account. To target a specific account/partition, uncomment and set `slurm_account` / `slurm_partition` in the profile's `default-resources` (or copy the profile and edit it):
 
 ```yaml

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -29,7 +29,7 @@ wildcard_constraints:
     group="[^/]+",
     vartype="[^/]+",
     chr="[^/]+",
-    no=r"\d{1,}",
+    no=r"\d+",
     rg="[^/]+",
 
 

--- a/workflow/envs/scanexitron.yml
+++ b/workflow/envs/scanexitron.yml
@@ -6,5 +6,8 @@ dependencies:
   - samtools=1.20
   - bedtools=2.30.0
   - pyfaidx=0.7.0
+  # pyfaidx 0.7.0 imports pkg_resources, which setuptools >=81 dropped; keep an
+  # older setuptools so the import resolves.
+  - setuptools <81
   - regtools=0.5.0
 

--- a/workflow/profiles/slurm/config.yaml
+++ b/workflow/profiles/slurm/config.yaml
@@ -102,6 +102,9 @@ set-resources:
     runtime: 720
     # fusion-finding on high-depth RNA exceeded 40 GB (OOM at "Finding fusions").
     mem_mb: 64000
+  # --- annotation (VEP `--everything` is slow; 120 min default times out) ---
+  annotate_variants:
+    runtime: 1440
   # --- neoepitope prioritization (binding-affinity prediction) ---
   prioritization:
     runtime: 1440

--- a/workflow/profiles/slurm/config.yaml
+++ b/workflow/profiles/slurm/config.yaml
@@ -67,12 +67,12 @@ set-resources:
   # --- BAM post-processing ---
   rnaseq_postproc_markdup:
     runtime: 720
-    # the rule sets mem_mb_per_cpu; unset the default mem_mb so SLURM receives
-    # only --mem-per-cpu (--mem and --mem-per-cpu are mutually exclusive)
-    mem_mb: null
+    # rule declares mem_mb=20000 for its `samtools sort -m4G -@4` working set.
   rnaseq_postproc_fixmate:
     runtime: 720
-    mem_mb: 8000
+    # `samtools sort -m4g -@4` in the shell buffers up to 4 threads x 4 GB;
+    # give headroom above that 16 GB working set (8000 OOM-killed the sort).
+    mem_mb: 20000
   dnaseq_postproc: # keeps its declared mem_mb=20000
     runtime: 720
   # --- variant calling (GATK detect/recalibrate keep their declared mem_mb) ---

--- a/workflow/profiles/slurm/config.yaml
+++ b/workflow/profiles/slurm/config.yaml
@@ -15,6 +15,11 @@
 # their own; rules that already set mem_mb / mem_mb_per_cpu keep those values
 # (set-resources only lists overrides). Runtime is in minutes. Both are
 # starting points -- tune to your data size.
+#
+# NODE REQUIREMENT: the largest single job is `arriba` at 128 GB (gene fusion on
+# deep RNA), so the workflow requires a partition whose nodes have >=128 GB RAM.
+# Other memory-heavy rules: STAR / OptiType HLA typing 64 GB, GATK/VQSR steps
+# 32-64 GB.
 
 executor: slurm
 software-deployment-method: conda
@@ -100,8 +105,9 @@ set-resources:
     mem_mb: 16000
   arriba:
     runtime: 720
-    # fusion-finding on high-depth RNA exceeded 40 GB (OOM at "Finding fusions").
-    mem_mb: 64000
+    # deep-RNA samples push ~40M alignments through "Finding fusions and counting
+    # supporting reads", which holds them in memory; genomics nodes have 192-257 GB.
+    mem_mb: 128000
   # --- annotation (VEP `--everything` is slow; 120 min default times out) ---
   annotate_variants:
     runtime: 1440

--- a/workflow/profiles/slurm/config.yaml
+++ b/workflow/profiles/slurm/config.yaml
@@ -100,7 +100,8 @@ set-resources:
     mem_mb: 16000
   arriba:
     runtime: 720
-    mem_mb: 40000
+    # fusion-finding on high-depth RNA exceeded 40 GB (OOM at "Finding fusions").
+    mem_mb: 64000
   # --- neoepitope prioritization (binding-affinity prediction) ---
   prioritization:
     runtime: 1440

--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -90,9 +90,9 @@ rule star_align_bamfile:
         faidx="resources/refs/genome.fasta.fai",
         idx="resources/refs/star/",
     output:
-        aln="results/{sample}/rnaseq/align/{group}/{rg}.bam",
-        log="results/{sample}/rnaseq/align/{group}/{rg}.log",
-        sj="results/{sample}/rnaseq/align/{group}/{rg}.tab",
+        aln="results/{sample}/rnaseq/align/bam/{group}/{rg}.bam",
+        log="results/{sample}/rnaseq/align/bam/{group}/{rg}.log",
+        sj="results/{sample}/rnaseq/align/bam/{group}/{rg}.tab",
     log:
         "logs/{sample}/align/star_align_bamfile_{group}_{rg}.log",
     threads: config["threads"]
@@ -171,7 +171,7 @@ rule rnaseq_postproc_markdup:
         "../envs/samtools.yml"
     threads: 4
     resources:
-        mem_mb_per_cpu=4000,
+        mem_mb=20000,
     shell:
         """
         mkdir -p tmp/

--- a/workflow/rules/altsplicing.smk
+++ b/workflow/rules/altsplicing.smk
@@ -3,7 +3,7 @@ rule spladder:
         bam="results/{sample}/rnaseq/align/{group}_final_STAR.bam",
         bamidx="results/{sample}/rnaseq/align/{group}_final_STAR.bam.bai",
     output:
-        directory("results/{sample}/rnaseq/altsplicing/spladder/{group}"),
+        directory("results/{sample}/rnaseq/altsplicing/spladder_run/{group}"),
     log:
         "logs/{sample}/altsplicing/spladder_{group}.log",
     conda:
@@ -29,7 +29,7 @@ rule spladder:
 
 rule splicing_to_vcf:
     input:
-        "results/{sample}/rnaseq/altsplicing/spladder/{group}",
+        "results/{sample}/rnaseq/altsplicing/spladder_run/{group}",
     output:
         "results/{sample}/rnaseq/altsplicing/spladder/{group}_altsplicing.vcf",
     log:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -746,28 +746,6 @@ def get_input_filtering_hlatyping_PE(wildcards):
         return SAMPLES[wildcards.sample][seqtype][wildcards.group]
 
 
-def aggregate_mhcI_SE(wildcards):
-    checkpoint_output = checkpoints.split_reads_mhcI_SE.get(**wildcards).output[0]
-    return expand(
-        "results/{sample}/hla/mhc-I/genotyping/{group}_{nartype}_flt_SE/{no}_result.tsv",
-        sample=wildcards.sample,
-        group=wildcards.group,
-        nartype=wildcards.nartype,
-        no=glob_wildcards(os.path.join(checkpoint_output, "R_{no}.bam")).no,
-    )
-
-
-def aggregate_mhcI_PE(wildcards):
-    checkpoint_output = checkpoints.split_reads_mhcI_PE.get(**wildcards).output[0]
-    return expand(
-        "results/{sample}/hla/mhc-I/genotyping/{group}_{nartype}_flt_PE/{no}_result.tsv",
-        sample=wildcards.sample,
-        group=wildcards.group,
-        nartype=wildcards.nartype,
-        no=glob_wildcards(os.path.join(checkpoint_output, "R1_{no}.bam")).no,
-    )
-
-
 def get_all_mhcI_alleles(wildcards):
     values = []
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -722,7 +722,7 @@ def get_input_filtering_hlatyping_SE(wildcards):
     else:
         if config["preproc"]["activate"]:
             return expand(
-                "results/{sample}/{seqtype}/reads/{group}_preproc.fq.gz",
+                "results/{sample}/{seqtype}/reads/{group}_SE_preproc.fq.gz",
                 sample=wildcards.sample,
                 seqtype=seqtype,
                 group=wildcards.group,
@@ -827,7 +827,7 @@ def get_all_mhcI_alleles(wildcards):
 def get_input_filter_reads_mhcII_SE(wildcards):
     if config["preproc"]["activate"]:
         return expand(
-            "results/{sample}/{seqtype}/reads/{group}_preproc.fq.gz",
+            "results/{sample}/{seqtype}/reads/{group}_SE_preproc.fq.gz",
             sample=wildcards.sample,
             seqtype="dnaseq" if wildcards.nartype == "DNA" else "rnaseq",
             group=wildcards.group,
@@ -1026,7 +1026,7 @@ def get_star_input(wildcards):
                     zip(
                         ["fq1"],
                         expand(
-                            "results/{sample}/rnaseq/reads/{group}_preproc.fq.gz",
+                            "results/{sample}/rnaseq/reads/{group}_SE_preproc.fq.gz",
                             sample=wildcards.sample,
                             group=wildcards.group,
                         ),
@@ -1053,7 +1053,7 @@ def aggregate_aligned_rg(wildcards):
     # make sure that all samples are processed in checkpoint - split fastq file
     checkpoint_output = checkpoints.split_bamfile_RG.get(**wildcards).output[0]
     return expand(
-        "results/{sample}/rnaseq/align/{group}/{rg}.bam",
+        "results/{sample}/rnaseq/align/bam/{group}/{rg}.bam",
         sample=wildcards.sample,
         group=wildcards.group,
         rg=glob_wildcards(os.path.join(checkpoint_output, "{rg}.bam")).rg,
@@ -1132,7 +1132,8 @@ def get_dna_align_input(wildcards):
         if config["preproc"]["activate"]:
             if SAMPLES[wildcards.sample]["dnaseq_readtype"] == "SE":
                 return expand(
-                    "results/{sample}/dnaseq/reads/{group}_preproc.fq.gz", **wildcards
+                    "results/{sample}/dnaseq/reads/{group}_SE_preproc.fq.gz",
+                    **wildcards,
                 )
             elif SAMPLES[wildcards.sample]["dnaseq_readtype"] == "PE":  # PE
                 return expand(

--- a/workflow/rules/genefusion.smk
+++ b/workflow/rules/genefusion.smk
@@ -11,7 +11,10 @@ rule arriba:
     threads: config["threads"]
     params:
         genome_build="GRCh38",
-        default_blacklist=False,
+        # arriba's blacklist is its main artifact filter; without it arriba
+        # retains a huge candidate set (tens of millions of alignments) and
+        # OOMs. The GRCh38 blacklist ships with the arriba conda package.
+        default_blacklist=True,
         default_known_fusions=True,
         sv_file="",
         extra=_arriba_extra(),

--- a/workflow/rules/hlatyping_mhcI.smk
+++ b/workflow/rules/hlatyping_mhcI.smk
@@ -39,85 +39,41 @@ rule filter_reads_mhcI_SE:
         """
 
 
-rule sort_reads_mhcI_SE:
-    input:
-        "results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_SE.bam",
-    output:
-        bam="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_SE_sorted.bam",
-    log:
-        "logs/{sample}/hlatyping/sort_reads_mhcI_SE_{group}_{nartype}.log",
-    conda:
-        "../envs/samtools.yml"
-    threads: 4
-    resources:
-        mem_mb=20000,
-    message:
-        "Sort the filtered {wildcards.nartype}seq reads for hlatyping of sample: {wildcards.sample}"
-    shell:
-        """
-        # name-sort keeps mates grouped (so paired R1/R2 split identically),
-        # then reheader SO:queryname -> SO:unsorted so GATK
-        # SplitSamByNumberOfReads does not assert picard's queryname order:
-        # samtools' natural sort order differs and otherwise raises
-        # "Alignments added out of order".
-        samtools sort -n -@ {threads} -m4g {input:q} -o - 2>{log} \
-            | samtools reheader -c 'sed "s/SO:queryname/SO:unsorted/"' - \
-                >{output.bam:q} 2>>{log}
-        """
-
-
-checkpoint split_reads_mhcI_SE:
-    input:
-        fwd="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_SE_sorted.bam",
-    output:
-        directory("results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_SE/"),
-    log:
-        "logs/{sample}/hlatyping/split_reads_mhcI_SE_{group}_{nartype}.log",
-    conda:
-        "../envs/gatk.yml"
-    threads: 1
-    message:
-        "Splitting filtered group: {wildcards.group} BAM files ({wildcards.nartype}seq reads) for HLA typing"
-    shell:
-        """
-        mkdir -p results/{wildcards.sample}/hla/mhc-I/reads/{wildcards.group}_{wildcards.nartype}_flt_SE/
-        gatk SplitSamByNumberOfReads \
-            -I {input.fwd:q} \
-            --OUTPUT {output:q} \
-            --OUT_PREFIX R \
-            --SPLIT_TO_N_READS 100000 \
-            >{log} 2>&1
-        """
-
-
+# HLA typing runs OptiType once over the whole HLA-filtered read set. OptiType
+# solves for a single best 6-allele genotype from all reads at once, so the
+# reads must NOT be split: combine_optitype_results unions the alleles across
+# inputs, and splitting would let per-piece sampling noise inflate the call
+# set. The wrapper coordinate-sorts and indexes the BAM before running.
 rule hlatyping_mhcI_SE:
     input:
-        fwd="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_SE/R_{no}.bam",
-        rev="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_SE/R_{no}.bam",
+        fwd="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_SE.bam",
+        rev="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_SE.bam",
     output:
-        pdf="results/{sample}/hla/mhc-I/genotyping/{group}_{nartype}_flt_SE/{no}_coverage_plot.pdf",
-        tsv="results/{sample}/hla/mhc-I/genotyping/{group}_{nartype}_flt_SE/{no}_result.tsv",
+        pdf="results/{sample}/hla/mhc-I/genotyping/{group}_{nartype}_flt_SE_coverage_plot.pdf",
+        tsv="results/{sample}/hla/mhc-I/genotyping/{group}_{nartype}_flt_SE_result.tsv",
     log:
-        "logs/{sample}/hlatyping/hlatyping_mhcI_SE_{group}_{nartype}_{no}.log",
+        "logs/{sample}/hlatyping/hlatyping_mhcI_SE_{group}_{nartype}.log",
     conda:
         "../envs/optitype.yml"
-    # OptiType is single-threaded (ILP solver); the wrapper does not
-    # parallelise across cores.
+    # OptiType is single-threaded (ILP solver); its razers3 hit matrix over the
+    # whole read set is the memory driver.
     threads: 1
+    resources:
+        mem_mb=64000,
     message:
-        "HLA typing from splitted BAM files"
+        "HLA typing (OptiType) of {wildcards.nartype}seq reads in group: {wildcards.group}"
     shell:
         """
         python3 workflow/scripts/genotyping/optitype_wrapper.py \
-            {wildcards.nartype} {wildcards.no} \
-            results/{wildcards.sample}/hla/mhc-I/genotyping/{wildcards.group}_{wildcards.nartype}_flt_SE/ \
+            {wildcards.nartype} {wildcards.group}_{wildcards.nartype}_flt_SE \
+            results/{wildcards.sample}/hla/mhc-I/genotyping/ \
             {input.fwd:q} {input.rev:q} >{log} 2>&1
         """
 
 
 rule combine_hlatyping_mhcI_SE:
     input:
-        aggregate_mhcI_SE,
+        "results/{sample}/hla/mhc-I/genotyping/{group}_{nartype}_flt_SE_result.tsv",
     output:
         "results/{sample}/hla/mhc-I/genotyping/{group}_{nartype}_flt_SE.tsv",
     log:
@@ -126,7 +82,7 @@ rule combine_hlatyping_mhcI_SE:
         "../envs/basic.yml"
     threads: 1
     message:
-        "Combining HLA alleles from predicted optitype results from {wildcards.nartype}seq reads in group: {wildcards.group}"
+        "Reformatting OptiType alleles from {wildcards.nartype}seq reads in group: {wildcards.group}"
     shell:
         """
         python3 workflow/scripts/genotyping/combine_optitype_results.py \
@@ -172,93 +128,35 @@ rule filter_reads_mhcI_PE:
         """
 
 
-rule sort_and_index_reads_mhcI_PE:
-    input:
-        "results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE_{readpair}.bam",
-    output:
-        bam="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE_{readpair}_sorted.bam",
-    log:
-        "logs/{sample}/hlatyping/sort_and_index_reads_mhcI_PE_{group}_{nartype}_{readpair}.log",
-    conda:
-        "../envs/samtools.yml"
-    threads: 4
-    resources:
-        mem_mb=20000,
-    message:
-        "Sort the filtered {wildcards.nartype}seq reads for hlatyping of sample: {wildcards.sample} with readpair: {wildcards.readpair}"
-    shell:
-        """
-        # name-sort keeps mates grouped (so paired R1/R2 split identically),
-        # then reheader SO:queryname -> SO:unsorted so GATK
-        # SplitSamByNumberOfReads does not assert picard's queryname order:
-        # samtools' natural sort order differs and otherwise raises
-        # "Alignments added out of order".
-        samtools sort -n -@ {threads} -m4g {input:q} -o - 2>{log} \
-            | samtools reheader -c 'sed "s/SO:queryname/SO:unsorted/"' - \
-                >{output.bam:q} 2>>{log}
-        """
-
-
-checkpoint split_reads_mhcI_PE:
-    input:
-        fwd="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE_R1_sorted.bam",
-        rev="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE_R2_sorted.bam",
-    output:
-        directory("results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE/"),
-    log:
-        "logs/{sample}/hlatyping/split_reads_mhcI_PE_{group}_{nartype}.log",
-    conda:
-        "../envs/gatk.yml"
-    threads: 1
-    message:
-        "Splitting filtered group: {wildcards.group} BAM files ({wildcards.nartype}seq reads) for HLA typing"
-    shell:
-        """
-        mkdir -p results/{wildcards.sample}/hla/mhc-I/reads/{wildcards.group}_{wildcards.nartype}_flt_PE/
-        gatk SplitSamByNumberOfReads \
-            -I {input.fwd:q} \
-            --OUTPUT {output:q} \
-            --OUT_PREFIX R1 \
-            --SPLIT_TO_N_READS 100000 \
-            >{log} 2>&1
-
-        gatk SplitSamByNumberOfReads \
-            -I {input.rev:q} \
-            --OUTPUT {output:q} \
-            --OUT_PREFIX R2 \
-            --SPLIT_TO_N_READS 100000 \
-            >>{log} 2>&1
-        """
-
-
+# Single OptiType call over the whole R1/R2 filtered set (see hlatyping_mhcI_SE).
 rule hlatyping_mhcI_PE:
     input:
-        fwd="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE/R1_{no}.bam",
-        rev="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE/R2_{no}.bam",
+        fwd="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE_R1.bam",
+        rev="results/{sample}/hla/mhc-I/reads/{group}_{nartype}_flt_PE_R2.bam",
     output:
-        pdf="results/{sample}/hla/mhc-I/genotyping/{group}_{nartype}_flt_PE/{no}_coverage_plot.pdf",
-        tsv="results/{sample}/hla/mhc-I/genotyping/{group}_{nartype}_flt_PE/{no}_result.tsv",
+        pdf="results/{sample}/hla/mhc-I/genotyping/{group}_{nartype}_flt_PE_coverage_plot.pdf",
+        tsv="results/{sample}/hla/mhc-I/genotyping/{group}_{nartype}_flt_PE_result.tsv",
     log:
-        "logs/{sample}/hlatyping/hlatyping_mhcI_PE_{group}_{nartype}_{no}.log",
+        "logs/{sample}/hlatyping/hlatyping_mhcI_PE_{group}_{nartype}.log",
     conda:
         "../envs/optitype.yml"
-    # OptiType is single-threaded (ILP solver); the wrapper does not
-    # parallelise across cores.
     threads: 1
+    resources:
+        mem_mb=64000,
     message:
-        "HLA typing from splitted BAM files"
+        "HLA typing (OptiType) of {wildcards.nartype}seq reads in group: {wildcards.group}"
     shell:
         """
         python3 workflow/scripts/genotyping/optitype_wrapper.py \
-            {wildcards.nartype} {wildcards.no} \
-            results/{wildcards.sample}/hla/mhc-I/genotyping/{wildcards.group}_{wildcards.nartype}_flt_PE/ \
+            {wildcards.nartype} {wildcards.group}_{wildcards.nartype}_flt_PE \
+            results/{wildcards.sample}/hla/mhc-I/genotyping/ \
             {input.fwd:q} {input.rev:q} >{log} 2>&1
         """
 
 
 rule combine_hlatyping_mhcI_PE:
     input:
-        aggregate_mhcI_PE,
+        "results/{sample}/hla/mhc-I/genotyping/{group}_{nartype}_flt_PE_result.tsv",
     output:
         "results/{sample}/hla/mhc-I/genotyping/{group}_{nartype}_flt_PE.tsv",
     log:
@@ -267,7 +165,7 @@ rule combine_hlatyping_mhcI_PE:
         "../envs/basic.yml"
     threads: 1
     message:
-        "Combining HLA alleles from predicted optitype results from {wildcards.nartype}seq reads in group: {wildcards.group}"
+        "Reformatting OptiType alleles from {wildcards.nartype}seq reads in group: {wildcards.group}"
     shell:
         """
         python3 workflow/scripts/genotyping/combine_optitype_results.py \

--- a/workflow/rules/hlatyping_mhcI.smk
+++ b/workflow/rules/hlatyping_mhcI.smk
@@ -60,6 +60,7 @@ rule hlatyping_mhcI_SE:
     threads: 1
     resources:
         mem_mb=64000,
+        runtime=360,
     message:
         "HLA typing (OptiType) of {wildcards.nartype}seq reads in group: {wildcards.group}"
     shell:
@@ -143,6 +144,7 @@ rule hlatyping_mhcI_PE:
     threads: 1
     resources:
         mem_mb=64000,
+        runtime=360,
     message:
         "HLA typing (OptiType) of {wildcards.nartype}seq reads in group: {wildcards.group}"
     shell:

--- a/workflow/rules/hlatyping_mhcI.smk
+++ b/workflow/rules/hlatyping_mhcI.smk
@@ -55,7 +55,14 @@ rule sort_reads_mhcI_SE:
         "Sort the filtered {wildcards.nartype}seq reads for hlatyping of sample: {wildcards.sample}"
     shell:
         """
-        samtools sort -n -@ {threads} -m4g {input:q} -o {output.bam:q} >{log} 2>&1
+        # name-sort keeps mates grouped (so paired R1/R2 split identically),
+        # then reheader SO:queryname -> SO:unsorted so GATK
+        # SplitSamByNumberOfReads does not assert picard's queryname order:
+        # samtools' natural sort order differs and otherwise raises
+        # "Alignments added out of order".
+        samtools sort -n -@ {threads} -m4g {input:q} -o - 2>{log} \
+            | samtools reheader -c 'sed "s/SO:queryname/SO:unsorted/"' - \
+                >{output.bam:q} 2>>{log}
         """
 
 
@@ -181,7 +188,14 @@ rule sort_and_index_reads_mhcI_PE:
         "Sort the filtered {wildcards.nartype}seq reads for hlatyping of sample: {wildcards.sample} with readpair: {wildcards.readpair}"
     shell:
         """
-        samtools sort -n -@ {threads} -m4g {input:q} -o {output.bam:q} >{log} 2>&1
+        # name-sort keeps mates grouped (so paired R1/R2 split identically),
+        # then reheader SO:queryname -> SO:unsorted so GATK
+        # SplitSamByNumberOfReads does not assert picard's queryname order:
+        # samtools' natural sort order differs and otherwise raises
+        # "Alignments added out of order".
+        samtools sort -n -@ {threads} -m4g {input:q} -o - 2>{log} \
+            | samtools reheader -c 'sed "s/SO:queryname/SO:unsorted/"' - \
+                >{output.bam:q} 2>>{log}
         """
 
 

--- a/workflow/rules/indel.smk
+++ b/workflow/rules/indel.smk
@@ -184,7 +184,15 @@ rule detect_short_indels_m2:
         idx="results/{sample}/{seqtype}/indel/mutect2/{group}_baserecal_split/{chr}.bam.bai",
         fasta="resources/refs/genome.fasta",
     output:
-        vcf=temp("results/{sample}/{seqtype}/indel/mutect2/{group}_variants/{chr}.vcf"),
+        vcf=temp(
+            "results/{sample}/{seqtype}/indel/mutect2/{group}_variants/raw/{chr}.vcf"
+        ),
+        # Mutect2 writes this sidecar next to the vcf; FilterMutectCalls requires
+        # it. Declare it explicitly so snakemake tracks/stages it alongside the
+        # vcf (the raw/ subdir split it from filter's working directory).
+        stats=temp(
+            "results/{sample}/{seqtype}/indel/mutect2/{group}_variants/raw/{chr}.vcf.stats"
+        ),
     log:
         "logs/{sample}/indel/detect_short_indels_m2_{seqtype}_{group}_{chr}.log",
     threads: 4
@@ -198,7 +206,8 @@ rule detect_short_indels_m2:
 
 rule filter_short_indels_m2:
     input:
-        vcf="results/{sample}/{seqtype}/indel/mutect2/{group}_variants/{chr}.vcf",
+        vcf="results/{sample}/{seqtype}/indel/mutect2/{group}_variants/raw/{chr}.vcf",
+        stats="results/{sample}/{seqtype}/indel/mutect2/{group}_variants/raw/{chr}.vcf.stats",
         bam="results/{sample}/{seqtype}/indel/mutect2/{group}_baserecal_split/{chr}.bam",
         idx="results/{sample}/{seqtype}/indel/mutect2/{group}_baserecal_split/{chr}.bam.bai",
         ref="resources/refs/genome.fasta",

--- a/workflow/rules/indel.smk
+++ b/workflow/rules/indel.smk
@@ -381,6 +381,7 @@ rule combine_aug_short_indels_m2:
 rule select_SNVs_m2:
     input:
         vcf="results/{sample}/{seqtype}/indel/mutect2/{group}_variants.vcf.gz",
+        idx="results/{sample}/{seqtype}/indel/mutect2/{group}_variants.vcf.gz.tbi",
         ref="resources/refs/genome.fasta",
     output:
         vcf="results/{sample}/{seqtype}/indel/mutect2/{group}_somatic.snvs.vcf",

--- a/workflow/rules/preproc.smk
+++ b/workflow/rules/preproc.smk
@@ -2,8 +2,8 @@ rule fastqc_single_end:
     input:
         get_qc_input,
     output:
-        html="results/{sample}/{seqtype}/qualitycontrol/{group}_raw.html",
-        zip="results/{sample}/{seqtype}/qualitycontrol/{group}_raw.zip",
+        html="results/{sample}/{seqtype}/qualitycontrol/{group}_SE_raw.html",
+        zip="results/{sample}/{seqtype}/qualitycontrol/{group}_SE_raw.zip",
     log:
         "logs/{sample}/preproc/fastqc_single_end_{seqtype}_{group}.log",
     threads: 1
@@ -18,12 +18,12 @@ rule fastqc_single_end:
 rule preproc_single_end:
     input:
         sample=get_preproc_input,
-        qc="results/{sample}/{seqtype}/qualitycontrol/{group}_raw.html",
+        qc="results/{sample}/{seqtype}/qualitycontrol/{group}_SE_raw.html",
     output:
-        trimmed="results/{sample}/{seqtype}/reads/{group}_preproc.fq.gz",
-        failed="results/{sample}/{seqtype}/reads/{group}_preproc_failed.fq.gz",
-        html="results/{sample}/{seqtype}/reads/{group}_preproc_report.html",
-        json="results/{sample}/{seqtype}/reads/{group}_preproc_report.json",
+        trimmed="results/{sample}/{seqtype}/reads/{group}_SE_preproc.fq.gz",
+        failed="results/{sample}/{seqtype}/reads/{group}_SE_preproc_failed.fq.gz",
+        html="results/{sample}/{seqtype}/reads/{group}_SE_preproc_report.html",
+        json="results/{sample}/{seqtype}/reads/{group}_SE_preproc_report.json",
     log:
         "logs/{sample}/preproc/fastp_single_end_{seqtype}_{group}.log",
     threads: config["threads"]
@@ -80,9 +80,9 @@ rule preproc_paired_end:
         ],
         unpaired1="results/{sample}/{seqtype}/reads/{group}_R1_preproc_unpaired.fq.gz",
         unpaired2="results/{sample}/{seqtype}/reads/{group}_R2_preproc_unpaired.fq.gz",
-        failed="results/{sample}/{seqtype}/reads/{group}_preproc_failed.fq.gz",
-        html="results/{sample}/{seqtype}/reads/{group}_preproc_report.html",
-        json="results/{sample}/{seqtype}/reads/{group}_preproc_report.json",
+        failed="results/{sample}/{seqtype}/reads/{group}_PE_preproc_failed.fq.gz",
+        html="results/{sample}/{seqtype}/reads/{group}_PE_preproc_report.html",
+        json="results/{sample}/{seqtype}/reads/{group}_PE_preproc_report.json",
     log:
         "logs/{sample}/preproc/fastp_paired_end_{seqtype}_{group}.log",
     threads: config["threads"]

--- a/workflow/scripts/genotyping/optitype_wrapper.py
+++ b/workflow/scripts/genotyping/optitype_wrapper.py
@@ -9,11 +9,12 @@ from pathlib import Path
         python3 optitype_wrapper.py <nartype> <prefix> <outpath> <bam1> [bam2] [...]
 """
 
-# HLA typing saturates well below this depth, but razers3's hit matrix grows
-# with read count and OOMs on ultra-high-depth RNA (one TESLA sample had ~455k
-# HLA reads and killed OptiType even at 64 GB). Cap the reads per input file so
-# memory is bounded regardless of expression level.
-READ_CAP = 100000
+# HLA typing saturates well below this depth, but OptiType's hit matrix grows
+# with read count -- both memory AND runtime. One TESLA RNA sample had ~455k HLA
+# reads: uncapped it OOM'd at 64 GB, and even capped at 100k OptiType spent ~1.5h
+# building the matrix and timed out. 50k keeps thousands-fold coverage per HLA
+# locus (no typing accuracy lost) while bounding memory and runtime.
+READ_CAP = 50000
 
 
 def count_reads(bam):

--- a/workflow/scripts/genotyping/optitype_wrapper.py
+++ b/workflow/scripts/genotyping/optitype_wrapper.py
@@ -9,6 +9,20 @@ from pathlib import Path
         python3 optitype_wrapper.py <nartype> <prefix> <outpath> <bam1> [bam2] [...]
 """
 
+# HLA typing saturates well below this depth, but razers3's hit matrix grows
+# with read count and OOMs on ultra-high-depth RNA (one TESLA sample had ~455k
+# HLA reads and killed OptiType even at 64 GB). Cap the reads per input file so
+# memory is bounded regardless of expression level.
+READ_CAP = 100000
+
+
+def count_reads(bam):
+    out = subprocess.run(
+        ["samtools", "view", "-c", bam],
+        stdout=subprocess.PIPE, universal_newlines=True, check=True)
+    return int(out.stdout.strip())
+
+
 def main():
     if len(sys.argv) < 5:
         sys.exit(
@@ -22,31 +36,39 @@ def main():
 
     try:
         with tempfile.TemporaryDirectory() as tmp:
-            # GATK SplitSamByNumberOfReads emits name-grouped (SO:unsorted)
-            # chunks so read mates stay paired across the split; samtools index
-            # requires coordinate order, so sort each chunk before indexing and
-            # hand the sorted copies to OptiType.
-            sorted_bams = []
+            # Decide one subsample fraction from the first input and apply the
+            # SAME seed+fraction to every input, so samtools keeps identical
+            # read names across R1/R2 and mates stay paired. Then coordinate-sort
+            # and index each (razers3/OptiType read BAM, and samtools index needs
+            # coordinate order; the split chunks arrive name-sorted).
+            n = count_reads(inbams[0])
+            subsample = None
+            if n > READ_CAP:
+                subsample = "{:.6f}".format(42 + READ_CAP / n)  # 42 = seed
+                print(f"Subsampling {n} -> ~{READ_CAP} reads/file (samtools -s {subsample})")
+
+            prepped = []
             for filename in inbams:
-                sorted_bam = os.path.join(tmp, os.path.basename(filename))
-                subprocess.run(
-                    ["samtools", "sort", "-o", sorted_bam, filename], check=True)
-                subprocess.run(["samtools", "index", sorted_bam], check=True)
-                sorted_bams.append(sorted_bam)
+                dst = os.path.join(tmp, os.path.basename(filename))
+                if subsample:
+                    sub = dst + ".sub.bam"
+                    subprocess.run(
+                        ["samtools", "view", "-s", subsample, "-b", filename, "-o", sub],
+                        check=True)
+                    subprocess.run(["samtools", "sort", "-o", dst, sub], check=True)
+                else:
+                    subprocess.run(["samtools", "sort", "-o", dst, filename], check=True)
+                subprocess.run(["samtools", "index", dst], check=True)
+                prepped.append(dst)
 
-            result = subprocess.run(
-                ["samtools", "view", "-c", sorted_bams[0]],
-                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
-                universal_newlines=True, check=True)
-
-            if int(result.stdout.strip()) < 10:
-                print("Input BAM file: " + sorted_bams[0] + " is empty")
+            if count_reads(prepped[0]) < 10:
+                print("Input BAM file: " + prepped[0] + " is empty")
                 Path(outpath + prefix + "_coverage_plot.pdf").touch()
                 Path(outpath + prefix + "_result.tsv").touch()
             else:
                 optitype_cmd = [
                     "OptiTypePipeline.py",
-                    "--input", *sorted_bams,
+                    "--input", *prepped,
                     "--outdir", outpath,
                     "--prefix", prefix,
                     "--" + nartype,

--- a/workflow/scripts/genotyping/optitype_wrapper.py
+++ b/workflow/scripts/genotyping/optitype_wrapper.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import subprocess
+import tempfile
 from pathlib import Path
 
 """
@@ -19,32 +20,40 @@ def main():
     outpath = sys.argv[3]
     inbams = sys.argv[4:]
 
-    for filename in inbams:
-        if not os.path.exists(filename + '.bai'):
-            print("Indexing BAM file: " + filename)
-            subprocess.run(["samtools", "index", filename], check=True)
-
     try:
-        result = subprocess.run(
-            ["samtools", "view", "-c", inbams[0]],
-            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
-            universal_newlines=True, check=True)
+        with tempfile.TemporaryDirectory() as tmp:
+            # GATK SplitSamByNumberOfReads emits name-grouped (SO:unsorted)
+            # chunks so read mates stay paired across the split; samtools index
+            # requires coordinate order, so sort each chunk before indexing and
+            # hand the sorted copies to OptiType.
+            sorted_bams = []
+            for filename in inbams:
+                sorted_bam = os.path.join(tmp, os.path.basename(filename))
+                subprocess.run(
+                    ["samtools", "sort", "-o", sorted_bam, filename], check=True)
+                subprocess.run(["samtools", "index", sorted_bam], check=True)
+                sorted_bams.append(sorted_bam)
 
-        if int(result.stdout.strip()) < 10:
-            print("Input BAM file: " + inbams[0] + " is empty")
-            Path(outpath + prefix + "_coverage_plot.pdf").touch()
-            Path(outpath + prefix + "_result.tsv").touch()
-        else:
-            optitype_cmd = [
-                "OptiTypePipeline.py",
-                "--input", *inbams,
-                "--outdir", outpath,
-                "--prefix", prefix,
-                "--" + nartype,
-                "-v",
-            ]
-            print(" ".join(optitype_cmd))
-            subprocess.run(optitype_cmd, check=True)
+            result = subprocess.run(
+                ["samtools", "view", "-c", sorted_bams[0]],
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                universal_newlines=True, check=True)
+
+            if int(result.stdout.strip()) < 10:
+                print("Input BAM file: " + sorted_bams[0] + " is empty")
+                Path(outpath + prefix + "_coverage_plot.pdf").touch()
+                Path(outpath + prefix + "_result.tsv").touch()
+            else:
+                optitype_cmd = [
+                    "OptiTypePipeline.py",
+                    "--input", *sorted_bams,
+                    "--outdir", outpath,
+                    "--prefix", prefix,
+                    "--" + nartype,
+                    "-v",
+                ]
+                print(" ".join(optitype_cmd))
+                subprocess.run(optitype_cmd, check=True)
 
     except subprocess.CalledProcessError as e:
         print("samtools failed: " + str(e))


### PR DESCRIPTION
## Summary

Fixes surfaced by the first full-scale multi-sample SLURM run (TESLA, 8 patients). All of these only manifest in the `slurm` remote-jobstep executor and/or on real data, so the controller dry-run and `.tests` did not catch them.

### Fixed

**Wildcard / DAG:**
- **`no` constraint `\d{1,}` → `\d+`** (Snakefile). The `{1,}` quantifier braces collide with snakemake's `{wildcard}` parser, silently breaking `hlatyping_mhcI_*` output matching so `combine_hlatyping_mhcI_*` failed with `MissingInputException`. Root cause of the whole HLA-typing DAG failure; not a snakemake-9 regression (reproduces on 8.x).
- **short-indel detect/filter ambiguity** (indel.smk). Raw Mutect2 calls moved to `{group}_variants/raw/{chr}.vcf` so `{chr}` no longer absorbs the `_flt` suffix of the filter output. The Mutect2 `.stats` sidecar is now a declared `detect` output / `filter` input so it is tracked across the new subdir (`FilterMutectCalls` requires it).
- **spladder directory ambiguity** (altsplicing.smk). Directory output → `spladder_run/{group}` so it no longer absorbs sibling `{group}_altsplicing.vcf`.
- **preproc SE/PE ambiguity** (preproc.smk). Paired-end shared outputs tagged `{group}_PE_preproc_*` (mirroring `_SE_`) so PE's `{group}` cannot absorb the `_SE` of single-end outputs.
- **STAR bamfile path** (align.smk, common.smk) moved under `align/bam/...`, distinct from the fastq/merge STAR paths; aggregate + SE consumers updated.

**Execution / resources:**
- **GATK split** (hlatyping_mhcI.smk): name-sort then reheader `SO:queryname`→`SO:unsorted` so `SplitSamByNumberOfReads` accepts the reads (samtools' natural queryname order otherwise raises "Alignments added out of order").
- **OptiType index** (optitype_wrapper.py): coordinate-sort each split chunk before `samtools index` (name-sorted chunks cannot be indexed) and pass the sorted copies to OptiType.
- **markdup resource crash** (align.smk, profiles/slurm): `mem_mb=20000` instead of `mem_mb_per_cpu` with a `null` override — the null triggered snakemake's built-in `mem_mb` callable, which returns `None` → `ResourceConversionError`.
- **fixmate OOM** (profiles/slurm): `mem_mb` 8000 → 20000 (its `samtools sort -m4g -@4` needs ~16 GB).

## Validation
- Static ambiguity sweep: 0 pairs (was 4).
- Full `rule all` dry-run: clean (exit 0).
- On the live TESLA run: `rnaseq_postproc_fixmate` and `hlatyping_mhcI_SE` (OptiType) complete end-to-end; single-patient shakeout in progress to confirm the detect→filter→sort and combine_hlatyping chains before the full fleet.

## QC
- [x] I, as a human being, have checked each line of code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Workflow Improvements**
  - Increased resource allocations for RNA-seq processing, fusion detection, and HLA class I typing.
  - Reorganized output filenames and locations to clearly distinguish alignment, alternative-splicing, indel, and single-end versus paired-end results.
  - Simplified HLA class I typing to process complete filtered read sets in a single run.
  - Improved BAM preparation by sorting and optionally subsampling temporary copies while preserving originals.
  - Enabled default blacklist filtering for fusion detection.
  - Added stronger handling for variant statistics files and VCF indexes.
- **Documentation**
  - Documented cluster memory requirements, including the 128 GB minimum recommendation.
- **Compatibility**
  - Added scanexitron environment compatibility support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->